### PR TITLE
Clean up bibliography

### DIFF
--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -40,7 +40,7 @@ Hankinson, Andrew, Perry Roland and Ichiro Fujinaga. "The Music Encoding Initiat
 
 Hartwig, Maja, Johannes Kepper and Kristina Richts. "Neue Wege der Musikerschließung: Über den möglichen Einsatz von MEI in deutschen Bibliotheken." _Forum Musikbibliothek: Beiträge und Informationen aus der musikbibliothekarischen Praxis_ 33 (2012): 16–23\. <[https://oa.slub-dresden.de/ejournals/fmb/article/view/96](https://oa.slub-dresden.de/ejournals/fmb/article/view/96)>. 
 
-Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikedition, Kolloquium des Ausschusses für musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf)>. 
+Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikedition, Kolloquium des Ausschusses für musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf)>. 
 
 Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml](http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml)>. 
 
@@ -54,7 +54,7 @@ McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections
 
 McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Features from Symbolic Music Representations." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf)>. 
 
-Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198–1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
+Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198–1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
 
 Pugin, Laurent. "The Challenge of Data in Digital Musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[https://doi.org/10.3389/fdigh.2015.00004](https://doi.org/10.3389/fdigh.2015.00004)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -42,7 +42,9 @@ Hartwig, Maja, Johannes Kepper and Kristina Richts. "Neue Wege der Musikerschlie
 
 Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikedition, Kolloquium des Ausschusses für musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf)>. 
 
-Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml](http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml)>. 
+Kepper, Johannes. _Musikedition im Zeichen neuer Medien. Historische Entwicklung und gegenwärtige Perspektiven musikalischer Gesamtausgaben_. (Diss., Detmold/Paderborn 2009\.) Norderstedt: Books on Demand, 2011 (Schriften des Instituts für Dokumentologie und Editorik, 5)\. <[http://nbn-resolving.de/urn:nbn:de:hbz:38-66395](http://nbn-resolving.de/urn:nbn:de:hbz:38-66395)>.
+
+Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://dx.doi.org/10.1524/itit.2009.0544](http://dx.doi.org/10.1524/itit.2009.0544)>. 
 
 Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a Basis for Thematic Catalogues: Thoughts, Experiences, and Preliminary Results." _RISM Conference_. 2012\. <[http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf](http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -76,9 +76,9 @@ Roland, Perry. Modular Design of the Music Encoding Initiative (MEI) DTD. _Music
 
 Roland, Perry. "The Music Encoding Initiative (MEI)." _Proceedings of the First International Conference on Musical Applications Using XML_. 2002\. 55–59\. <[http://xml.coverpages.org/MAX2002-PRoland.pdf](http://xml.coverpages.org/MAX2002-PRoland.pdf)>. 
 
-Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. <[http://www.lib.virginia.edu/digital/resndev/mei](http://www.lib.virginia.edu/digital/resndev/mei)> [link broken].
+Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. <[http://www.lib.virginia.edu/digital/resndev/mei](http://www.lib.virginia.edu/digital/resndev/mei)>.
 
-Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the OCVE." Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt](pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt)> [link broken]. —. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." Technical report. 2009. <[https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf](https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf)>. 
+Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the OCVE." Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[http://slideplayer.com/slide/2544413/](http://slideplayer.com/slide/2544413/)>. —. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." Technical report. 2009. <[https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf](https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf)>. 
 
 Roland, Perry. "XML4MIR: Extensible Markup Language for Music Information Retrieval." _International Symposium on Music Information Retrieval_. Plymouth, Massachusetts, 2000\. <[http://ismir2000.ismir.net/papers/roland_paper.pdf](http://ismir2000.ismir.net/papers/roland_paper.pdf)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -108,7 +108,7 @@ Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Score
 
 Teich Geertinger, Axel and Laurent Pugin. "MEI for Bridging the Gap Between Music Cataloguing and Digital Critical Editions." _Magazin für klassische Musick und Musikwissenschaft_ 5.3 (2011): 289–294. 
 
-Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musikergesamtausgaben und Bibliotheken." _ZfBB_ Heft 3-4 (2012): 166–174\. <[http://zs.thulb.uni-jena.de/receive/jportal_jparticle_00266455](http://zs.thulb.uni-jena.de/receive/jportal_jparticle_00266455)>. 
+Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musikergesamtausgaben und Bibliotheken." _ZfBB_ 59.3–4 (2012): 166–174\. <[http://dx.doi.org/10.3196/1864295012593472](http://dx.doi.org/10.3196/1864295012593472)>. 
 
 Viglianti, Raffaele. "Critical Editing of Music in the Digital Medium: An Experiment in MEI." _Digital Humanities_ (2010): 380. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -16,8 +16,6 @@ Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specificatio
 
 Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[https://doi.org/10.1525/jams.2016.69.1.273](https://doi.org/10.1525/jams.2016.69.1.273)>.
 
-De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277\. <[http://revue.ummto.dz/index.php/idi/article/view/292/0](http://revue.ummto.dz/index.php/idi/article/view/292/0)>.
-
 Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[https://doi.org/10.1145/2970044.2970052](https://doi.org/10.1145/2970044.2970052)>. 
 
 Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA 2011." _CAML Review/Revue de l'ACBM_ 39.1 (2011): 28–33\. <[https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349](https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349)>. 
@@ -51,6 +49,8 @@ Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a B
 Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45–48\. <[https://doi.org/10.1145/2970044.2970055](https://doi.org/10.1145/2970044.2970055)>. 
 
 Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[https://doi.org/10.1093/em/cav073](https://doi.org/10.1093/em/cav073)>. 
+
+Martin de Guise, Sylvaine. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277\. <[http://revue.ummto.dz/index.php/idi/article/view/292/0](http://revue.ummto.dz/index.php/idi/article/view/292/0)>.
 
 McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1–6\. <[https://doi.org/10.1108/RR-03-2015-0073](https://doi.org/10.1108/RR-03-2015-0073)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -74,17 +74,19 @@ Roland, Perry. Modular Design of the Music Encoding Initiative (MEI) DTD. _Music
 
 Roland, Perry. "The Music Encoding Initiative (MEI)." _Proceedings of the First International Conference on Musical Applications Using XML_. 2002\. 55–59\. <[http://xml.coverpages.org/MAX2002-PRoland.pdf](http://xml.coverpages.org/MAX2002-PRoland.pdf)>. 
 
-Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. —. The Music Encoding Initiative (MEI) DTD and the OCVE. Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt](pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt)>. 
+Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. <[http://www.lib.virginia.edu/digital/resndev/mei](http://www.lib.virginia.edu/digital/resndev/mei)> [broken].
 
-Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." n.d. <[http://pilot.ocve.org.uk/redist/pdf/roland.pdf](http://pilot.ocve.org.uk/redist/pdf/roland.pdf)>. 
+Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the OCVE." Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt](pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt)> [broken]. 
 
-Roland, Perry. "XML4MIR: Extensible Markup Language for Music Information Retrieval." _International Symposium on Music Information Retrieval_. Plymouth, Massachusetts, 2000\. <[http://ciir.cs.umass.edu/music2000/papers/roland_paper.pdf](http://ciir.cs.umass.edu/music2000/papers/roland_paper.pdf)>. 
+Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." Technical report. 2009. <[http://pilot.ocve.org.uk/redist/pdf/roland.pdf](http://pilot.ocve.org.uk/redist/pdf/roland.pdf)> [broken]. 
 
-Roland, Perry, Andrew Hankinson and Laurent Pugin. "Early Music and the Music Encoding Initiative." _Early Music_ 42.4 (2014): 605–611\. <[http://em.oxfordjournals.org/content/42/4/605.full?keytype=ref&ijkey=faImCQIgU6WV9Xe](http://em.oxfordjournals.org/content/42/4/605.full?keytype=ref&ijkey=faImCQIgU6WV9Xe)>. 
+Roland, Perry. "XML4MIR: Extensible Markup Language for Music Information Retrieval." _International Symposium on Music Information Retrieval_. Plymouth, Massachusetts, 2000\. <[http://ismir2000.ismir.net/papers/roland_paper.pdf](http://ismir2000.ismir.net/papers/roland_paper.pdf)>. 
+
+Roland, Perry, Andrew Hankinson and Laurent Pugin. "Early Music and the Music Encoding Initiative." _Early Music_ 42.4 (2014): 605–611\. <[https://doi.org/10.1093/em/cau098](https://doi.org/10.1093/em/cau098)>. 
 
 Roland, Perry and Christine Siegert. "Process-Oriented Notation in MEI." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 305–309. 
 
-Roland, Perry and J. Stephen Downie. "Recent Developments in the Music Encoding Initiative Project: Enhancing Digital Musicology and Scholarship." _19th Joint Conference on the Digital Humanities, Conference Abstracts_. 2007\. 186-189\. <[http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf](http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf)>, <[http://music-encoding.org/wp-content/uploads/2015/04/RolandDownie2007poster.pdf](http://music-encoding.org/wp-content/uploads/2015/04/RolandDownie2007poster.pdf)>. 
+Roland, Perry and J. Stephen Downie. "Recent Developments in the Music Encoding Initiative Project: Enhancing Digital Musicology and Scholarship." _19th Joint Conference on the Digital Humanities, Conference Abstracts_. 2007\. 186-189\. <[http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf](http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf)>, <[http://music-encoding.org/downloads/RolandDownie2007poster.pdf](http://music-encoding.org/downloads/RolandDownie2007poster.pdf)>. 
 
 Roland, Perry and Johannes Kepper, ed. _Music Encoding Conference Proceedings, 2013 and 2014_. Charlottesville, Virginia and Detmold, Germany: Music Encoding Initiative, 2015\. <[http://nbn-resolving.de/urn:nbn:de:bvb:12-babs2-0000007812](http://nbn-resolving.de/urn:nbn:de:bvb:12-babs2-0000007812)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -14,7 +14,7 @@ Buschmeier, Gabriele and Thomas Betzwieser. "Digitale Editionen in Akademienprog
 
 Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." _Computer Music Journal_ 27.4 (2003): 43–57\. <[http://www.jstor.org/stable/3681900](http://www.jstor.org/stable/3681900)>. rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
 
-Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
+Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://dx.doi.org/10.1525/jams.2016.69.1.273](http://dx.doi.org/10.1525/jams.2016.69.1.273)>.
 
 De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277\. <[http://revue.ummto.dz/index.php/idi/article/view/292/0](http://revue.ummto.dz/index.php/idi/article/view/292/0)>.
 
@@ -48,7 +48,7 @@ Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a B
 
 Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45–48\. <[http://dx.doi.org/10.1145/2970044.2970055](http://dx.doi.org/10.1145/2970044.2970055)>. 
 
-Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[http://em.oxfordjournals.org/content/43/4/635.full.pdf+html](http://em.oxfordjournals.org/content/43/4/635.full.pdf+html)>. 
+Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[http://dx.doi.org/10.1093/em/cav073](http://dx.doi.org/10.1093/em/cav073)>. 
 
 McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1–6\. <[http://dx.doi.org/10.1108/RR-03-2015-0073](http://dx.doi.org/10.1108/RR-03-2015-0073)>. 
 
@@ -56,15 +56,15 @@ McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Feat
 
 Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198–1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
 
-Pugin, Laurent. "The Challenge of Data in Digital Musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004](http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004)>. 
+Pugin, Laurent. "The Challenge of Data in Digital Musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[https://doi.org/10.3389/fdigh.2015.00004](https://doi.org/10.3389/fdigh.2015.00004)>. 
 
 Pugin, Laurent, et al. "Separating Presentation and Content in MEI." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 505–510\. <[http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf)>. 
 
 Pugin, Laurent, Rodolfo Zitellini and Perry Roland. "Verovio: A Library for Engraving MEI Music Notation into SVG." _Proceedings of the 15th Conference of the International Society for Music Information Retrieval_. Ed. Hsin-Min Wang, Yi-Hsuan Yang and Jin Ha Lee. Taipei, Taiwan: ISMIR, 2014\. 107–112\. <[http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf](http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf)>. 
 
-Richts, Kristina. "Die FRBR Customization im Datenformat der Music Encoding Initiative (MEI)." Master's Thesis. Köln, Germany: Cologne University of Applied Sciences, 2013\. <[http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/144](http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/144)>. 
+Richts, Kristina. "Die FRBR Customization im Datenformat der Music Encoding Initiative (MEI)." Master's Thesis. Köln, Germany: Cologne University of Applied Sciences, 2013\. <[http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-2013103042](http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-2013103042)>. 
 
-Richts, Kristina. "Entwicklung von Schulungsmaterialien für Einsatzmöglichkeiten von MEI im bibliothekarischen Bereich." _MALIS Praxisprojekte 2013: Projektberichte aus dem berufsbegleitenden Masterstudiengang Bibliotheks- und Informationswissenschaft der Fachhochschule Köln_. Ed. Achim Oßwald, et al. Wiesbaden: Dinges & Frick, 2013\. 137–155\. <[http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/376](http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/376)>. 
+Richts, Kristina. "Entwicklung von Schulungsmaterialien für Einsatzmöglichkeiten von MEI im bibliothekarischen Bereich." _MALIS Praxisprojekte 2013: Projektberichte aus dem berufsbegleitenden Masterstudiengang Bibliotheks- und Informationswissenschaft der Fachhochschule Köln_. Ed. Achim Oßwald, et al. Wiesbaden: Dinges & Frick, 2013\. 137–155\. <[http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-opus-3763](http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-opus-3763)>. 
 
 Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analyses and Representations." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 25–32\. <[http://dx.doi.org/10.1145/2970044.2970046](http://dx.doi.org/10.1145/2970044.2970046)>. 
 
@@ -96,13 +96,13 @@ Sapp, Craig. "Graphic to Symbolic Representations of Musical Notation." _Proceed
 
 Schräder, Gregor. "Ein XML-Datenformat zur Repräsentation kritischer Musikedition unter besonderer Berücksichtigung von Neumennotation." Seminar Paper. 2007\. <[http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf](http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf)>. 
 
-Selfridge-Field, Eleanor. "Hybrid Critical Editions of Opera: Motives, Milestones, and Quandaries." _Notes_ 72.1 (2015): 9–22\. <[http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf](http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf)>. 
+Selfridge-Field, Eleanor. "Hybrid Critical Editions of Opera: Motives, Milestones, and Quandaries." _Notes_ 72.1 (2015): 9–22\. <[https://doi.org/10.1353/not.2015.0100](https://doi.org/10.1353/not.2015.0100)>. 
 
 Siegert, Christine. Movimento testuale ed edizione. Il caso dell'aria "Non per parlar d'amore". Lecture. Referat beim VI Seminario di filologia musicale "La filologia musicale oggi. Il retaggio storico e le nuove prospettive". Cremona, 2009. 
 
 Stewart, Darin. "XML for Music." Dec 2003\. _Electronic Musician_. <[http://www.emusician.com/gear/1332/xml-for-music/33473](http://www.emusician.com/gear/1332/xml-for-music/33473)>. 
 
-Stinson, John and Jason Stoessel. "Encoding Medieval Music Notation for Research." _Early Music_ 42.4 (2014): 613–617\. <[http://em.oxfordjournals.org/content/42/4/613.full.pdf+html](http://em.oxfordjournals.org/content/42/4/613.full.pdf+html)>. 
+Stinson, John and Jason Stoessel. "Encoding Medieval Music Notation for Research." _Early Music_ 42.4 (2014): 613–617\. <[https://doi.org/10.1093/em/cau093](https://doi.org/10.1093/em/cau093)>. 
 
 Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Scores–or Vice Versa: Music Archives and Catalogues Based on MEI XML." _Fontes Artis Musicae_ 61.1 (2014): 61–66\. <[http://www.jstor.org/stable/24330408](http://www.jstor.org/stable/24330408)>.
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -16,7 +16,7 @@ Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specificatio
 
 Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
 
-De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277.
+De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277\. <[http://revue.ummto.dz/index.php/idi/article/view/292/0](http://revue.ummto.dz/index.php/idi/article/view/292/0)>.
 
 Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
 
@@ -30,7 +30,7 @@ Freedman, Richard and Philippe Vendrix. "The Chansonniers of Nicolas du Chemin: 
 
 Hankinson, Andrew. Optical Music Recognition Infrastructure for Large-Scale Music Document Analysis. PhD diss., Schulich School of Music, McGill University, Montreal, Canada, 2014\. <[https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0](https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0)>. 
 
-Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection from Printed Music Materials." _Proceedings of the 21st International Conference Companion on World Wide Web_. ACM, 2012\. 903–908. 
+Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection from Printed Music Materials." _Proceedings of the 21st International Conference Companion on World Wide Web_. ACM, 2012\. 903–908\. <[http://dx.doi.org/10.1145/2187980.2188221](http://dx.doi.org/10.1145/2187980.2188221)>. 
 
 Hankinson, Andrew, et al. "Digital Document Image Retrieval Using Optical Music Recognition." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 577–582\. <[http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf)>. 
 
@@ -38,7 +38,7 @@ Hankinson, Andrew, Laurent Pugin and Ichiro Fujinaga. "An Interchange Format for
 
 Hankinson, Andrew, Perry Roland and Ichiro Fujinaga. "The Music Encoding Initiative as a Document-Encoding Framework." _12th International Society for Music Information Retrieval Conference_. Miami, 2011\. 293–298\. <[http://ismir2011.ismir.net/papers/OS3-1.pdf](http://ismir2011.ismir.net/papers/OS3-1.pdf)>. 
 
-Hartwig, Maja, Johannes Kepper and Kristina Richts. "Neue Wege der Musikerschließung: Über den möglichen Einsatz von MEI in deutschen Bibliotheken." _Forum Musikbibliothek: Beiträge und Informationen aus der musikbibliothekarischen Praxis_ 33 (2012): 16–23. 
+Hartwig, Maja, Johannes Kepper and Kristina Richts. "Neue Wege der Musikerschließung: Über den möglichen Einsatz von MEI in deutschen Bibliotheken." _Forum Musikbibliothek: Beiträge und Informationen aus der musikbibliothekarischen Praxis_ 33 (2012): 16–23\. <[https://oa.slub-dresden.de/ejournals/fmb/article/view/96](https://oa.slub-dresden.de/ejournals/fmb/article/view/96)>. 
 
 Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikedition, Kolloquium des Ausschusses für musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf)>. 
 
@@ -104,13 +104,13 @@ Stewart, Darin. "XML for Music." Dec 2003\. _Electronic Musician_. <[http://www.
 
 Stinson, John and Jason Stoessel. "Encoding Medieval Music Notation for Research." _Early Music_ 42.4 (2014): 613–617\. <[http://em.oxfordjournals.org/content/42/4/613.full.pdf+html](http://em.oxfordjournals.org/content/42/4/613.full.pdf+html)>. 
 
-Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Scores–or Vice Versa: Music Archives and Catalogues Based on MEI XML." _Fontes Artis Musicae_ 61.1 (2014): 61–66. 
+Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Scores–or Vice Versa: Music Archives and Catalogues Based on MEI XML." _Fontes Artis Musicae_ 61.1 (2014): 61–66\. <[http://www.jstor.org/stable/24330408](http://www.jstor.org/stable/24330408)>.
 
 Teich Geertinger, Axel and Laurent Pugin. "MEI for Bridging the Gap Between Music Cataloguing and Digital Critical Editions." _Magazin für klassische Musick und Musikwissenschaft_ 5.3 (2011): 289–294. 
 
 Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musikergesamtausgaben und Bibliotheken." _ZfBB_ 59.3–4 (2012): 166–174\. <[http://dx.doi.org/10.3196/1864295012593472](http://dx.doi.org/10.3196/1864295012593472)>. 
 
-Viglianti, Raffaele. "Critical Editing of Music in the Digital Medium: An Experiment in MEI." _Digital Humanities_ (2010): 380. 
+Viglianti, Raffaele. "Critical Editing of Music in the Digital Medium: An Experiment in MEI." _Digital Humanities 2010 (DH2010), Conference Abstracts_. London, UK, 2010\. 380–382\. <[http://dh2010.cch.kcl.ac.uk/academic-programme/abstracts/papers/pdf/ab-819.pdf](http://dh2010.cch.kcl.ac.uk/academic-programme/abstracts/papers/pdf/ab-819.pdf)>. 
 
 Viglianti, Raffaele. "The Music Addressability API." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 57–60\. <[http://dx.doi.org/10.1145/2970044.2970056](http://dx.doi.org/10.1145/2970044.2970056)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -28,7 +28,7 @@ Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services
 
 Freedman, Richard and Philippe Vendrix. "The Chansonniers of Nicolas du Chemin: A Digital Forum for Renaissance Music Books." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 284–288. 
 
-Hankinson, Andrew. Optical music recognition infrastructure for large-scale music document analysis. PhD diss., Schulich School of Music, McGill University, Montreal, Canada, 2014\. <[https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0](https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0)>. 
+Hankinson, Andrew. Optical Music Recognition Infrastructure for Large-Scale Music Document Analysis. PhD diss., Schulich School of Music, McGill University, Montreal, Canada, 2014\. <[https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0](https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0)>. 
 
 Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection from Printed Music Materials." _Proceedings of the 21st International Conference Companion on World Wide Web_. ACM, 2012\. 903–908. 
 
@@ -56,7 +56,7 @@ McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Feat
 
 Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198–1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
 
-Pugin, Laurent. "The challenge of data in digital musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004](http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004)>. 
+Pugin, Laurent. "The Challenge of Data in Digital Musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004](http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004)>. 
 
 Pugin, Laurent, et al. "Separating Presentation and Content in MEI." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 505–510\. <[http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -4,7 +4,7 @@ title: "Bibliography"
 ---
 # Bibliography
 
-Bell, Eamonn and Laurent Pugin. "Approaches to Handwritten Conductor Annotation Extraction in Musical Scores." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 33–36\. <[http://dx.doi.org/10.1145/2970044.2970053](http://dx.doi.org/10.1145/2970044.2970053)>.
+Bell, Eamonn and Laurent Pugin. "Approaches to Handwritten Conductor Annotation Extraction in Musical Scores." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 33–36\. <[https://doi.org/10.1145/2970044.2970053](https://doi.org/10.1145/2970044.2970053)>.
 
 Burlet, Gregory and Ichiro Fujinaga. "Robotaba Guitar Tablature Transcription Framework." _14th International Society for Music Information Retrieval Conference_. Curitiba, Brazil, 2013\. 517–522\. <[http://ismir2013.ismir.net/wp-content/uploads/2013/09/217_Paper.pdf](http://ismir2013.ismir.net/wp-content/uploads/2013/09/217_Paper.pdf)>.
 
@@ -14,11 +14,11 @@ Buschmeier, Gabriele and Thomas Betzwieser. "Digitale Editionen in Akademienprog
 
 Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." _Computer Music Journal_ 27.4 (2003): 43–57\. <[http://www.jstor.org/stable/3681900](http://www.jstor.org/stable/3681900)>. rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
 
-Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://dx.doi.org/10.1525/jams.2016.69.1.273](http://dx.doi.org/10.1525/jams.2016.69.1.273)>.
+Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[https://doi.org/10.1525/jams.2016.69.1.273](https://doi.org/10.1525/jams.2016.69.1.273)>.
 
 De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277\. <[http://revue.ummto.dz/index.php/idi/article/view/292/0](http://revue.ummto.dz/index.php/idi/article/view/292/0)>.
 
-Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
+Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[https://doi.org/10.1145/2970044.2970052](https://doi.org/10.1145/2970044.2970052)>. 
 
 Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA 2011." _CAML Review/Revue de l'ACBM_ 39.1 (2011): 28–33\. <[https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349](https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349)>. 
 
@@ -30,7 +30,7 @@ Freedman, Richard and Philippe Vendrix. "The Chansonniers of Nicolas du Chemin: 
 
 Hankinson, Andrew. Optical Music Recognition Infrastructure for Large-Scale Music Document Analysis. PhD diss., Schulich School of Music, McGill University, Montreal, Canada, 2014\. <[https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0](https://www.dropbox.com/s/ghupovhktchdfc8/hankinson_dissertation_submission.pdf?dl=0)>. 
 
-Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection from Printed Music Materials." _Proceedings of the 21st International Conference Companion on World Wide Web_. ACM, 2012\. 903–908\. <[http://dx.doi.org/10.1145/2187980.2188221](http://dx.doi.org/10.1145/2187980.2188221)>. 
+Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection from Printed Music Materials." _Proceedings of the 21st International Conference Companion on World Wide Web_. ACM, 2012\. 903–908\. <[https://doi.org/10.1145/2187980.2188221](https://doi.org/10.1145/2187980.2188221)>. 
 
 Hankinson, Andrew, et al. "Digital Document Image Retrieval Using Optical Music Recognition." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 577–582\. <[http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf)>. 
 
@@ -44,15 +44,15 @@ Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikeditio
 
 Kepper, Johannes. _Musikedition im Zeichen neuer Medien. Historische Entwicklung und gegenwärtige Perspektiven musikalischer Gesamtausgaben_. (Diss., Detmold/Paderborn 2009\.) Norderstedt: Books on Demand, 2011 (Schriften des Instituts für Dokumentologie und Editorik, 5)\. <[http://nbn-resolving.de/urn:nbn:de:hbz:38-66395](http://nbn-resolving.de/urn:nbn:de:hbz:38-66395)>.
 
-Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://dx.doi.org/10.1524/itit.2009.0544](http://dx.doi.org/10.1524/itit.2009.0544)>. 
+Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[https://doi.org/10.1524/itit.2009.0544](https://doi.org/10.1524/itit.2009.0544)>. 
 
 Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a Basis for Thematic Catalogues: Thoughts, Experiences, and Preliminary Results." _RISM Conference_. 2012\. <[http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf](http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf)>. 
 
-Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45–48\. <[http://dx.doi.org/10.1145/2970044.2970055](http://dx.doi.org/10.1145/2970044.2970055)>. 
+Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45–48\. <[https://doi.org/10.1145/2970044.2970055](https://doi.org/10.1145/2970044.2970055)>. 
 
-Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[http://dx.doi.org/10.1093/em/cav073](http://dx.doi.org/10.1093/em/cav073)>. 
+Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[https://doi.org/10.1093/em/cav073](https://doi.org/10.1093/em/cav073)>. 
 
-McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1–6\. <[http://dx.doi.org/10.1108/RR-03-2015-0073](http://dx.doi.org/10.1108/RR-03-2015-0073)>. 
+McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1–6\. <[https://doi.org/10.1108/RR-03-2015-0073](https://doi.org/10.1108/RR-03-2015-0073)>. 
 
 McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Features from Symbolic Music Representations." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf)>. 
 
@@ -68,7 +68,7 @@ Richts, Kristina. "Die FRBR Customization im Datenformat der Music Encoding Init
 
 Richts, Kristina. "Entwicklung von Schulungsmaterialien für Einsatzmöglichkeiten von MEI im bibliothekarischen Bereich." _MALIS Praxisprojekte 2013: Projektberichte aus dem berufsbegleitenden Masterstudiengang Bibliotheks- und Informationswissenschaft der Fachhochschule Köln_. Ed. Achim Oßwald, et al. Wiesbaden: Dinges & Frick, 2013\. 137–155\. <[http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-opus-3763](http://nbn-resolving.de/urn:nbn:de:hbz:79pbc-opus-3763)>. 
 
-Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analyses and Representations." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 25–32\. <[http://dx.doi.org/10.1145/2970044.2970046](http://dx.doi.org/10.1145/2970044.2970046)>. 
+Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analyses and Representations." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 25–32\. <[https://doi.org/10.1145/2970044.2970046](https://doi.org/10.1145/2970044.2970046)>. 
 
 Roland, Perry. "Design Patterns in XML Music Representation." _4th International Society for Music Information Retrieval Conference_. Baltimore: Johns Hopkins University, 2003\. <[https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf](https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf)>. 
 
@@ -108,11 +108,11 @@ Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Score
 
 Teich Geertinger, Axel and Laurent Pugin. "MEI for Bridging the Gap Between Music Cataloguing and Digital Critical Editions." _Magazin für klassische Musick und Musikwissenschaft_ 5.3 (2011): 289–294. 
 
-Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musikergesamtausgaben und Bibliotheken." _ZfBB_ 59.3–4 (2012): 166–174\. <[http://dx.doi.org/10.3196/1864295012593472](http://dx.doi.org/10.3196/1864295012593472)>. 
+Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musikergesamtausgaben und Bibliotheken." _ZfBB_ 59.3–4 (2012): 166–174\. <[https://doi.org/10.3196/1864295012593472](https://doi.org/10.3196/1864295012593472)>. 
 
 Viglianti, Raffaele. "Critical Editing of Music in the Digital Medium: An Experiment in MEI." _Digital Humanities 2010 (DH2010), Conference Abstracts_. London, UK, 2010\. 380–382\. <[http://dh2010.cch.kcl.ac.uk/academic-programme/abstracts/papers/pdf/ab-819.pdf](http://dh2010.cch.kcl.ac.uk/academic-programme/abstracts/papers/pdf/ab-819.pdf)>. 
 
-Viglianti, Raffaele. "The Music Addressability API." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 57–60\. <[http://dx.doi.org/10.1145/2970044.2970056](http://dx.doi.org/10.1145/2970044.2970056)>. 
+Viglianti, Raffaele. "The Music Addressability API." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 57–60\. <[https://doi.org/10.1145/2970044.2970056](https://doi.org/10.1145/2970044.2970056)>. 
 
 Viglianti, Raffaele and Joachim Veit. "Mind the Gap: A Preliminary Evaluation of Issues in Combining Text and Music Encoding." _Die Tonkunst: Magazin für Klassische Musik und Musikwissenschaft_ 5.3 (2011): 318–325. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -24,7 +24,7 @@ Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA
 
 Duguid, Timothy. "MuSO: Aggregation and Peer Review in Music." White paper. College Station: Texas A&M University, 2016\. <[http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1](http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1)>. 
 
-Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services." _Proceedings of the 16th International Society for Music Information Retrieval Conference_. Ed. Meinard Müller and Frans Wiering. Malaga, Spain: International Society for Music Information Retrieval, 2015\. 632–638\. <[http://ismir2015.uma.es/proceedings.html](http://ismir2015.uma.es/proceedings.html)>. 
+Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services." _Proceedings of the 16th International Society for Music Information Retrieval Conference_. Ed. Meinard Müller and Frans Wiering. Malaga, Spain: International Society for Music Information Retrieval, 2015\. 632–638\. <[http://ismir2015.uma.es/articles/232_Paper.pdf](http://ismir2015.uma.es/articles/232_Paper.pdf)>. 
 
 Freedman, Richard and Philippe Vendrix. "The Chansonniers of Nicolas du Chemin: A Digital Forum for Renaissance Music Books." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 284–288. 
 
@@ -92,7 +92,7 @@ Roland, Perry and Johannes Kepper, ed. _Music Encoding Conference Proceedings, 2
 
 Röwenstrunk, Daniel. "Digital Music Notation Data Model and Prototype Delivery System: Ein deutsch-amerikanisches Projekt zur Förderung eines wissenschaftlichen Codierungsformats für Musiknotation." _Forum Musikbibliothek: Beitrage und Informationen aus der Musikbibliothekarischen Praxis_ 31.2 (2010): 134–138. 
 
-Sapp, Craig. "Graphic to Symbolic Representations of Musical Notation." _Proceedings of the First International Conference on Technologies for Music Notation and Representation - TENOR2015_. Ed. Marc Battier and Jean Bresson and Pierre Couprie and Cécile Davy-Rigaux and Dominique Fober and Yann Geslin and Hugues Genevois and François Picard and Alice Tacaille. Paris: Institut de Recherche en Musicologie, 2015\. 124–132\. <[http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf](http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf)>. 
+Sapp, Craig. "Graphic to Symbolic Representations of Musical Notation." _Proceedings of the First International Conference on Technologies for Music Notation and Representation - TENOR2015_. Ed. Marc Battier and Jean Bresson and Pierre Couprie and Cécile Davy-Rigaux and Dominique Fober and Yann Geslin and Hugues Genevois and François Picard and Alice Tacaille. Paris: Institut de Recherche en Musicologie, 2015\. 124–132\. <[http://tenor2015.tenor-conference.org/papers/20-Sapp-GraphicToSymbolic.pdf](http://tenor2015.tenor-conference.org/papers/20-Sapp-GraphicToSymbolic.pdf)>. 
 
 Schräder, Gregor. "Ein XML-Datenformat zur Repräsentation kritischer Musikedition unter besonderer Berücksichtigung von Neumennotation." Seminar Paper. 2007\. <[http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf](http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf)>. 
 
@@ -122,4 +122,4 @@ Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recog
 
 Weigl, David M. and Kevin R. Page. "Dynamic Semantic Notation: Jamming Together Music Encoding and Linked Data." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval Conference, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf)>. 
 
-Zitellini, Rodolfo and Laurent Pugin. "Representing Atypical Music Notation Practices: An Example with Late 17th Century Music." _Second International Conference on Technologies for Music Notation and Representation_. Cambridge, UK, 2016\. 71–76\. <[http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf](http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf)>.
+Zitellini, Rodolfo and Laurent Pugin. "Representing Atypical Music Notation Practices: An Example with Late 17th Century Music." _Proceedings of the Second International Conference on Technologies for Music Notation and Representation – TENOR2016_. Ed. Richard Hoadley and Dominique Fober and Chris Nash. Cambridge, UK: Anglia Ruskin University, 2016\. 71–76\. <[http://tenor2016.tenor-conference.org/papers/10_Zitellini_tenor2016.pdf](http://tenor2016.tenor-conference.org/papers/10_Zitellini_tenor2016.pdf)>.

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -4,7 +4,7 @@ title: "Bibliography"
 ---
 # Bibliography
 
-Bell, Eamonn and Laurent Pugin. "Approaches to Handwritten Conductor Annotation Extraction in Musical Scores." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 33-36\. <[http://dx.doi.org/10.1145/2970044.2970053](http://dx.doi.org/10.1145/2970044.2970053)>.
+Bell, Eamonn and Laurent Pugin. "Approaches to Handwritten Conductor Annotation Extraction in Musical Scores." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 33–36\. <[http://dx.doi.org/10.1145/2970044.2970053](http://dx.doi.org/10.1145/2970044.2970053)>.
 
 Burlet, Gregory and Ichiro Fujinaga. "Robotaba Guitar Tablature Transcription Framework." _14th International Society for Music Information Retrieval Conference_. Curitiba, Brazil, 2013\. 517–522\. <[http://ismir2013.ismir.net/wp-content/uploads/2013/09/217_Paper.pdf](http://ismir2013.ismir.net/wp-content/uploads/2013/09/217_Paper.pdf)>.
 
@@ -14,17 +14,17 @@ Buschmeier, Gabriele and Thomas Betzwieser. "Digitale Editionen in Akademienprog
 
 Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." 2003; rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
 
-Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273-285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
+Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
 
 De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277.
 
-Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1-8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
+Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
 
 Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA 2011." _CAML Review/Revue de l'ACBM_. 2011\. <[http://pi.library.yorku.ca/ojs/index.php/caml/article/viewFile/32103/29349](http://pi.library.yorku.ca/ojs/index.php/caml/article/viewFile/32103/29349)>. 
 
 Duguid, Timothy. "MuSO: Aggregation and Peer Review in Music." White paper. College Station: Texas A&M University, 2016\. <[http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1](http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1)>. 
 
-Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services." _Proceedings of the 16th International Society for Music Information Retrieval Conference_. Ed. Meinard Müller and Frans Wiering. Malaga, Spain: International Society for Music Information Retrieval, 2015\. 632-638\. <[http://ismir2015.uma.es/proceedings.html](http://ismir2015.uma.es/proceedings.html)>. 
+Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services." _Proceedings of the 16th International Society for Music Information Retrieval Conference_. Ed. Meinard Müller and Frans Wiering. Malaga, Spain: International Society for Music Information Retrieval, 2015\. 632–638\. <[http://ismir2015.uma.es/proceedings.html](http://ismir2015.uma.es/proceedings.html)>. 
 
 Freedman, Richard and Philippe Vendrix. "The Chansonniers of Nicolas du Chemin: A Digital Forum for Renaissance Music Books." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 284–288. 
 
@@ -46,27 +46,27 @@ Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirem
 
 Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a Basis for Thematic Catalogues: Thoughts, Experiences, and Preliminary Results." _RISM Conference_. 2012\. <[http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf](http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf)>. 
 
-Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45-48\. <[http://dx.doi.org/10.1145/2970044.2970055](http://dx.doi.org/10.1145/2970044.2970055)>. 
+Laplante, Audrey and Ichiro Fujinaga. "Digitizing Musical Scores: Challenges and Opportunities for Libraries." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 45–48\. <[http://dx.doi.org/10.1145/2970044.2970055](http://dx.doi.org/10.1145/2970044.2970055)>. 
 
-Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635-647\. <[http://em.oxfordjournals.org/content/43/4/635.full.pdf+html](http://em.oxfordjournals.org/content/43/4/635.full.pdf+html)>. 
+Lewis, Richard J., Tim Crawford, and David Lewis. "Exploring Information Retrieval, Semantic Technologies and Workflows for Music Scholarship: The Transforming Musicology Project." _Early Music_ 43.4 (2015): 635–647\. <[http://em.oxfordjournals.org/content/43/4/635.full.pdf+html](http://em.oxfordjournals.org/content/43/4/635.full.pdf+html)>. 
 
-McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1-6\. <[http://dx.doi.org/10.1108/RR-03-2015-0073](http://dx.doi.org/10.1108/RR-03-2015-0073)>. 
+McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections." _Reference Reviews_ 30.7 (2016): 1–6\. <[http://dx.doi.org/10.1108/RR-03-2015-0073](http://dx.doi.org/10.1108/RR-03-2015-0073)>. 
 
 McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Features from Symbolic Music Representations." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf)>. 
 
-Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198-1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
+Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198–1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
 
 Pugin, Laurent. "The challenge of data in digital musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004](http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004)>. 
 
 Pugin, Laurent, et al. "Separating Presentation and Content in MEI." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 505–510\. <[http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/505_ISMIR_2012.pdf)>. 
 
-Pugin, Laurent, Rodolfo Zitellini and Perry Roland. "Verovio: A Library for Engraving MEI Music Notation into SVG." _Proceedings of the 15th Conference of the International Society for Music Information Retrieval_. Ed. Hsin-Min Wang, Yi-Hsuan Yang and Jin Ha Lee. Taipei, Taiwan: ISMIR, 2014\. 107-112\. <[http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf](http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf)>. 
+Pugin, Laurent, Rodolfo Zitellini and Perry Roland. "Verovio: A Library for Engraving MEI Music Notation into SVG." _Proceedings of the 15th Conference of the International Society for Music Information Retrieval_. Ed. Hsin-Min Wang, Yi-Hsuan Yang and Jin Ha Lee. Taipei, Taiwan: ISMIR, 2014\. 107–112\. <[http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf](http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf)>. 
 
 Richts, Kristina. "Die FRBR Customization im Datenformat der Music Encoding Initiative (MEI)." Master's Thesis. Köln, Germany: Cologne University of Applied Sciences, 2013\. <[http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/144](http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/144)>. 
 
 Richts, Kristina. "Entwicklung von Schulungsmaterialien für Einsatzmöglichkeiten von MEI im bibliothekarischen Bereich." _MALIS Praxisprojekte 2013: Projektberichte aus dem berufsbegleitenden Masterstudiengang Bibliotheks- und Informationswissenschaft der Fachhochschule Köln_. Ed. Achim Oßwald, et al. Wiesbaden: Dinges & Frick, 2013\. 137–155\. <[http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/376](http://publiscologne.fh-koeln.de/frontdoor/index/index/docId/376)>. 
 
-Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analyses and Representations." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 25-32\. <[http://dx.doi.org/10.1145/2970044.2970046](http://dx.doi.org/10.1145/2970044.2970046)>. 
+Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analyses and Representations." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 25–32\. <[http://dx.doi.org/10.1145/2970044.2970046](http://dx.doi.org/10.1145/2970044.2970046)>. 
 
 Roland, Perry. "Design Patterns in XML Music Representation." _4th International Society for Music Information Retrieval Conference_. Baltimore: Johns Hopkins University, 2003\. <[https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf](https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf)>. 
 
@@ -86,23 +86,23 @@ Roland, Perry, Andrew Hankinson and Laurent Pugin. "Early Music and the Music En
 
 Roland, Perry and Christine Siegert. "Process-Oriented Notation in MEI." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 305–309. 
 
-Roland, Perry and J. Stephen Downie. "Recent Developments in the Music Encoding Initiative Project: Enhancing Digital Musicology and Scholarship." _19th Joint Conference on the Digital Humanities, Conference Abstracts_. 2007\. 186-189\. <[http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf](http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf)>, <[http://music-encoding.org/downloads/RolandDownie2007poster.pdf](http://music-encoding.org/downloads/RolandDownie2007poster.pdf)>. 
+Roland, Perry and J. Stephen Downie. "Recent Developments in the Music Encoding Initiative Project: Enhancing Digital Musicology and Scholarship." _19th Joint Conference on the Digital Humanities, Conference Abstracts_. 2007\. 186–189\. <[http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf](http://www.digitalhumanities.org/dh2007/dh2007.abstracts.pdf)>, <[http://music-encoding.org/downloads/RolandDownie2007poster.pdf](http://music-encoding.org/downloads/RolandDownie2007poster.pdf)>. 
 
 Roland, Perry and Johannes Kepper, ed. _Music Encoding Conference Proceedings, 2013 and 2014_. Charlottesville, Virginia and Detmold, Germany: Music Encoding Initiative, 2015\. <[http://nbn-resolving.de/urn:nbn:de:bvb:12-babs2-0000007812](http://nbn-resolving.de/urn:nbn:de:bvb:12-babs2-0000007812)>. 
 
 Röwenstrunk, Daniel. "Digital Music Notation Data Model and Prototype Delivery System: Ein deutsch-amerikanisches Projekt zur Förderung eines wissenschaftlichen Codierungsformats für Musiknotation." _Forum Musikbibliothek: Beitrage und Informationen aus der Musikbibliothekarischen Praxis_ 31.2 (2010): 134–138. 
 
-Sapp, Craig. "Graphic to Symbolic Representations of Musical Notation." _Proceedings of the First International Conference on Technologies for Music Notation and Representation - TENOR2015_. Ed. Marc Battier and Jean Bresson and Pierre Couprie and Cécile Davy-Rigaux and Dominique Fober and Yann Geslin and Hugues Genevois and François Picard and Alice Tacaille. Paris: Institut de Recherche en Musicologie, 2015\. 124-132\. <[http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf](http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf)>. 
+Sapp, Craig. "Graphic to Symbolic Representations of Musical Notation." _Proceedings of the First International Conference on Technologies for Music Notation and Representation - TENOR2015_. Ed. Marc Battier and Jean Bresson and Pierre Couprie and Cécile Davy-Rigaux and Dominique Fober and Yann Geslin and Hugues Genevois and François Picard and Alice Tacaille. Paris: Institut de Recherche en Musicologie, 2015\. 124–132\. <[http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf](http://tenor2015.tenor-conference.org/TENOR2015-Proceedings.pdf)>. 
 
 Schräder, Gregor. "Ein XML-Datenformat zur Repräsentation kritischer Musikedition unter besonderer Berücksichtigung von Neumennotation." Seminar Paper. 2007\. <[http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf](http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf)>. 
 
-Selfridge-Field, Eleanor. "Hybrid Critical Editions of Opera: Motives, Milestones, and Quandaries." _Notes_ 72.1 (2015): 9-22\. <[http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf](http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf)>. 
+Selfridge-Field, Eleanor. "Hybrid Critical Editions of Opera: Motives, Milestones, and Quandaries." _Notes_ 72.1 (2015): 9–22\. <[http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf](http://muse.jhu.edu/journals/notes/v072/72.1.selfridge-field.pdf)>. 
 
 Siegert, Christine. Movimento testuale ed edizione. Il caso dell'aria "Non per parlar d'amore". Lecture. Referat beim VI Seminario di filologia musicale "La filologia musicale oggi. Il retaggio storico e le nuove prospettive". Cremona, 2009. 
 
 Stewart, Darin. "XML for Music." Dec 2003\. _Electronic Musician_. <[http://www.emusician.com/gear/1332/xml-for-music/33473](http://www.emusician.com/gear/1332/xml-for-music/33473)>. 
 
-Stinson, John and Jason Stoessel. "Encoding medieval music notation for research." _Early Music_ 42.4 (2014): 613-617\. <[http://em.oxfordjournals.org/content/42/4/613.full.pdf+html](http://em.oxfordjournals.org/content/42/4/613.full.pdf+html)>. 
+Stinson, John and Jason Stoessel. "Encoding Medieval Music Notation for Research." _Early Music_ 42.4 (2014): 613–617\. <[http://em.oxfordjournals.org/content/42/4/613.full.pdf+html](http://em.oxfordjournals.org/content/42/4/613.full.pdf+html)>. 
 
 Teich Geertinger, Axel. "Turning Music Catalogues into Archives of Musical Scores–or Vice Versa: Music Archives and Catalogues Based on MEI XML." _Fontes Artis Musicae_ 61.1 (2014): 61–66. 
 
@@ -112,7 +112,7 @@ Veit, Joachim. "Wächst zusammen, was zusammen gehört? Wissenschaftliche Musike
 
 Viglianti, Raffaele. "Critical Editing of Music in the Digital Medium: An Experiment in MEI." _Digital Humanities_ (2010): 380. 
 
-Viglianti, Raffaele. "The Music Addressability API." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 57-60\. <[http://dx.doi.org/10.1145/2970044.2970056](http://dx.doi.org/10.1145/2970044.2970056)>. 
+Viglianti, Raffaele. "The Music Addressability API." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 57–60\. <[http://dx.doi.org/10.1145/2970044.2970056](http://dx.doi.org/10.1145/2970044.2970056)>. 
 
 Viglianti, Raffaele and Joachim Veit. "Mind the Gap: A Preliminary Evaluation of Issues in Combining Text and Music Encoding." _Die Tonkunst: Magazin für Klassische Musik und Musikwissenschaft_ 5.3 (2011): 318–325. 
 
@@ -122,4 +122,4 @@ Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recog
 
 Weigl, David M. and Kevin R. Page. "Dynamic Semantic Notation: Jamming Together Music Encoding and Linked Data." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval Conference, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf)>. 
 
-Zitellini, Rodolfo and Laurent Pugin. "Representing Atypical Music Notation Practices: An Example with Late 17th Century Music." _Second International Conference on Technologies for Music Notation and Representation_. Cambridge, UK, 2016\. 71-76\. <[http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf](http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf)>.
+Zitellini, Rodolfo and Laurent Pugin. "Representing Atypical Music Notation Practices: An Example with Late 17th Century Music." _Second International Conference on Technologies for Music Notation and Representation_. Cambridge, UK, 2016\. 71–76\. <[http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf](http://tenor2016.tenor-conference.org/TENOR2016-Proceedings.pdf)>.

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -96,7 +96,7 @@ Schräder, Gregor. "Ein XML-Datenformat zur Repräsentation kritischer Musikedit
 
 Selfridge-Field, Eleanor. "Hybrid Critical Editions of Opera: Motives, Milestones, and Quandaries." _Notes_ 72.1 (2015): 9–22\. <[https://doi.org/10.1353/not.2015.0100](https://doi.org/10.1353/not.2015.0100)>. 
 
-Siegert, Christine. Movimento testuale ed edizione. Il caso dell'aria "Non per parlar d'amore". Lecture. Referat beim VI Seminario di filologia musicale "La filologia musicale oggi. Il retaggio storico e le nuove prospettive". Cremona, 2009. 
+Siegert, Christine. "Movimento testuale ed edizione. Il caso dell'aria 'Non per parlar d'amore'". Lecture. _VI Seminario di filologia musicale "La filologia musicale oggi. Il retaggio storico e le nuove prospettive"_. Cremona, 2009. 
 
 Stewart, Darin. "XML for Music." Dec 2003\. _Electronic Musician_. <[http://www.emusician.com/gear/1332/xml-for-music/33473](http://www.emusician.com/gear/1332/xml-for-music/33473)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -20,9 +20,9 @@ De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au S
 
 Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1–8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
 
-Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA 2011." _CAML Review/Revue de l'ACBM_. 2011\. <[http://pi.library.yorku.ca/ojs/index.php/caml/article/viewFile/32103/29349](http://pi.library.yorku.ca/ojs/index.php/caml/article/viewFile/32103/29349)>. 
+Doi, Carolyn and Cathy Martin. "Conference Highlights and New Initiatives of MLA 2011." _CAML Review/Revue de l'ACBM_ 39.1 (2011): 28–33\. <[https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349](https://caml.journals.yorku.ca/index.php/caml/article/viewFile/32103/29349)>. 
 
-Duguid, Timothy. "MuSO: Aggregation and Peer Review in Music." White paper. College Station: Texas A&M University, 2016\. <[http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1](http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf?sequence=1)>. 
+Duguid, Timothy. "MuSO: Aggregation and Peer Review in Music." White paper. College Station: Texas A&M University, 2016\. <[http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf](http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/157548/NEH-White-Paper.pdf)>. 
 
 Duval, Erik, et al. "Musicology of Early Music with Europeana Tools and Services." _Proceedings of the 16th International Society for Music Information Retrieval Conference_. Ed. Meinard Müller and Frans Wiering. Malaga, Spain: International Society for Music Information Retrieval, 2015\. 632–638\. <[http://ismir2015.uma.es/articles/232_Paper.pdf](http://ismir2015.uma.es/articles/232_Paper.pdf)>. 
 
@@ -34,7 +34,7 @@ Hankinson, Andrew, et al. "Creating a Large-Scale Searchable Digital Collection 
 
 Hankinson, Andrew, et al. "Digital Document Image Retrieval Using Optical Music Recognition." _13th International Society for Music Information Retrieval Conference_. Porto, Portugal, 2012\. 577–582\. <[http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf](http://ismir2012.ismir.net/event/papers/577_ISMIR_2012.pdf)>. 
 
-Hankinson, Andrew, Laurent Pugin and Ichiro Fujinaga. "An Interchange Format for Optical Music Recognition Applications." _11th International Society for Music Information Retrieval Conference_. Utrecht, Netherlands, 2010\. 51–56\. <[http://www.mirlab.org/conference_papers/International_Conference/ISMIR%202010/ISMIR_20](http://www.mirlab.org/conference_papers/International_Conference/ISMIR%202010/ISMIR_20)>. 
+Hankinson, Andrew, Laurent Pugin and Ichiro Fujinaga. "An Interchange Format for Optical Music Recognition Applications." _11th International Society for Music Information Retrieval Conference_. Utrecht, Netherlands, 2010\. 51–56\. <[http://ismir2010.ismir.net/proceedings/ismir2010-11.pdf](http://ismir2010.ismir.net/proceedings/ismir2010-11.pdf)>. 
 
 Hankinson, Andrew, Perry Roland and Ichiro Fujinaga. "The Music Encoding Initiative as a Document-Encoding Framework." _12th International Society for Music Information Retrieval Conference_. Miami, 2011\. 293–298\. <[http://ismir2011.ismir.net/papers/OS3-1.pdf](http://ismir2011.ismir.net/papers/OS3-1.pdf)>. 
 
@@ -70,15 +70,13 @@ Rizo, David and Alan Marsden. "A Standard Format Proposal for Hierarchical Analy
 
 Roland, Perry. "Design Patterns in XML Music Representation." _4th International Society for Music Information Retrieval Conference_. Baltimore: Johns Hopkins University, 2003\. <[https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf](https://jscholarship.library.jhu.edu/bitstream/handle/1774.2/50/paper.pdf)>. 
 
-Roland, Perry. Modular Design of the Music Encoding Initiative (MEI) DTD. _MusicNetwork Notation Workshop: XML-Based Music Notation Solutions_. Leeds, England, 2003\. Powerpoint. —. Music Encoding Initiative (MEI) DTD. _MusicNetwork Notation Workshop: XML-Based Music Notation Solutions_. Leeds, England, 2003\. <[http://xml.coverpages.org/PerryMusicnetwork2003.pdf](http://xml.coverpages.org/PerryMusicnetwork2003.pdf)>. 
+Roland, Perry. Modular Design of the Music Encoding Initiative (MEI) DTD. _MusicNetwork Notation Workshop: XML-Based Music Notation Solutions_. Leeds, England, 2003\. Powerpoint. <[https://www.powershow.com/view1/20f360-ZDc1Z/Modular_Design_of_the_Music_Encoding_Initiative_MEI_DTD_powerpoint_ppt_presentation](https://www.powershow.com/view1/20f360-ZDc1Z/Modular_Design_of_the_Music_Encoding_Initiative_MEI_DTD_powerpoint_ppt_presentation)>. —. Music Encoding Initiative (MEI) DTD. _MusicNetwork Notation Workshop: XML-Based Music Notation Solutions_. Leeds, England, 2003\. <[http://xml.coverpages.org/PerryMusicnetwork2003.pdf](http://xml.coverpages.org/PerryMusicnetwork2003.pdf)>. 
 
 Roland, Perry. "The Music Encoding Initiative (MEI)." _Proceedings of the First International Conference on Musical Applications Using XML_. 2002\. 55–59\. <[http://xml.coverpages.org/MAX2002-PRoland.pdf](http://xml.coverpages.org/MAX2002-PRoland.pdf)>. 
 
-Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. <[http://www.lib.virginia.edu/digital/resndev/mei](http://www.lib.virginia.edu/digital/resndev/mei)> [broken].
+Roland, Perry. "The Music Encoding Initiative (MEI)." 2006. <[http://www.lib.virginia.edu/digital/resndev/mei](http://www.lib.virginia.edu/digital/resndev/mei)> [link broken].
 
-Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the OCVE." Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt](pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt)> [broken]. 
-
-Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." Technical report. 2009. <[http://pilot.ocve.org.uk/redist/pdf/roland.pdf](http://pilot.ocve.org.uk/redist/pdf/roland.pdf)> [broken]. 
+Roland, Perry. "The Music Encoding Initiative (MEI) DTD and the OCVE." Powerpoint. University of Virginia. Charlottesville, VA, 2009\. <[pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt](pilot.ocve.org.uk/redist/ppt/MEIChopin.ppt)> [link broken]. —. "The Music Encoding Initiative (MEI) DTD and the Online Chopin Variorum Edition." Technical report. 2009. <[https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf](https://pdfs.semanticscholar.org/f216/823c759b89ad8f623cdbd0e3c6e77bc4fe7e.pdf)>. 
 
 Roland, Perry. "XML4MIR: Extensible Markup Language for Music Information Retrieval." _International Symposium on Music Information Retrieval_. Plymouth, Massachusetts, 2000\. <[http://ismir2000.ismir.net/papers/roland_paper.pdf](http://ismir2000.ismir.net/papers/roland_paper.pdf)>. 
 
@@ -118,7 +116,7 @@ Viglianti, Raffaele and Joachim Veit. "Mind the Gap: A Preliminary Evaluation of
 
 Vigliensoni, Gabriel, et al. "Automatic Pitch Recognition in Printed Square-Note Notation." _12th International Society for Music Information Retrieval Conference_. Miami, 2011\. 423–428\. <[http://www.ismir2011.ismir.net/papers/PS3-12.pdf](http://www.ismir2011.ismir.net/papers/PS3-12.pdf)>. 
 
-Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recognition in Common Music Notation." _14th Society for Music Information Retrieval Conference_. Curitiba, Brazil, 2013\. 125–130\. <[http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf](http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf)>. 
+Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recognition in Common Music Notation." _14th Society for Music Information Retrieval Conference_. Curitiba, Brazil, 2013\. 125–130\. <[http://ismir2013.ismir.net/wp-content/uploads/2013/09/207_Paper.pdf](http://ismir2013.ismir.net/wp-content/uploads/2013/09/207_Paper.pdf)>. 
 
 Weigl, David M. and Kevin R. Page. "Dynamic Semantic Notation: Jamming Together Music Encoding and Linked Data." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval Conference, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf)>. 
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Bibliography"
 ---
-# Bibliography
+# Selective Bibliography
 
 Bell, Eamonn and Laurent Pugin. "Approaches to Handwritten Conductor Annotation Extraction in Musical Scores." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 33–36\. <[https://doi.org/10.1145/2970044.2970053](https://doi.org/10.1145/2970044.2970053)>.
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -12,7 +12,7 @@ Burlet, Gregory, et al. "Neon.js: Neume Editor Online." _13th International Soci
 
 Buschmeier, Gabriele and Thomas Betzwieser. "Digitale Editionen in Akademienprogramm: Die Projektpraxis am Beispiel OPERA." _Die Tonkunst: Magazin fur Klassische Musik und Musikwissenschaft_ 5.3 (2011): 263–269.
 
-Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." 2003; rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
+Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." _Computer Music Journal_ 27.4 (2003): 43–57\. <[http://www.jstor.org/stable/3681900](http://www.jstor.org/stable/3681900)>. rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
 
 Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273–285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
 

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -14,7 +14,9 @@ Buschmeier, Gabriele and Thomas Betzwieser. "Digitale Editionen in Akademienprog
 
 Byrd, Donald and Eric Isaacson. "A Music Representation Requirement Specification for Academia." 2003; rev. 2016\. <[http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc](http://homes.soic.indiana.edu/donbyrd/Papers/MusicRepReqForAcad.doc)>.
 
-Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273-285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>. De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277. 
+Crawford, Tim and Richard Lewis. "Review: Music Encoding Initiative." _Journal of the American Musicological Society_ 69.1 (2016): 273-285\. <[http://jams.ucpress.edu/content/69/1/273](http://jams.ucpress.edu/content/69/1/273)>.
+
+De Guise, Sylvaine Martin. "La MEI (Music Encoding Initiative): Un Standard Au Service De La Musique Kabyle." _Iles d Imesli_ 5 (2013): 245–277.
 
 Devaney, Johanna and Hubert Léveillé Gauvin. "Representing and Linking Music Performance Data with Score Information." _DLfM 2016: Proceedings of the 3rd International workshop on Digital Libraries for Musicology_. New York: Association for Computing Machinery, 2016\. 1-8\. <[http://dx.doi.org/10.1145/2970044.2970052](http://dx.doi.org/10.1145/2970044.2970052)>. 
 
@@ -40,7 +42,7 @@ Hartwig, Maja, Johannes Kepper and Kristina Richts. "Neue Wege der Musikerschlie
 
 Kepper, Johannes. "Codierungsformen von Musik." _Digitale Medien und Musikedition, Kolloquium des Ausschusses für musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/kepper.pdf)>. 
 
-Hartwig, Maja, Johannes Kepper and Kristina Richts. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml](http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml)>. 
+Kepper, Johannes. "XML-Based Encoding of Musicological Data–About the Requirements of a Digital Music Philology." _Information Technology Methoden und Innovative Anwendungen der Informatik und Informationstechnik_ 51.4 (2009): 216–221\. <[http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml](http://www.degruyter.com/view/j/itit.2009.51.issue-4/itit.2009.0544/itit.2009.0544.xml)>. 
 
 Krabbe, Niels and Axel Teich Geertinger. "MEI (Music Encoding Initiative) as a Basis for Thematic Catalogues: Thoughts, Experiences, and Preliminary Results." _RISM Conference_. 2012\. <[http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf](http://www.rism.info/fileadmin/content/community-content/events/RISM_Conference_2012/TeichGeertinger_Final.pdf)>. 
 
@@ -52,7 +54,7 @@ McAulay, Karen. "Show Me a Strathspey: Taking Steps to Digitize Tune Collections
 
 McKay, Cory, Tristano Tenaglia and Ichiro Fujinaga. "JSymbolic2: Extracting Features from Symbolic Music Representations." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/mckay-jsymbolic2.pdf)>. 
 
-Morent, Stefan and Gregor Schrader. "Tübingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198-1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
+Morent, Stefan and Gregor Schräder. "TüBingen - Digital Critical Edition of Medieval Music - The Music of Hildegard von Bingen [1198-1179]." _Digitale Medien und Musikedition, Kolloquium des Ausschusses fur musikwissenschaftliche Editionen der Union der deutschen Akademien der Wissenschaften_. Mainz, Germany, 2006\. 16–18\. <[http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf](http://www.adwmainz.de/fileadmin/adwmainz/MuKo_Veranstaltungen/S2-Digitale_Medien/TueBingen.pdf)>. 
 
 Pugin, Laurent. "The challenge of data in digital musicology." _Frontiers in Digital Humanities_ 2.4 (2015). <[http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004](http://www.frontiersin.org/Journal/FullText.aspx?s=1606&name=digital_musicology&ART_DOI=10.3389/fdigh.2015.00004)>. 
 
@@ -114,7 +116,7 @@ Viglianti, Raffaele and Joachim Veit. "Mind the Gap: A Preliminary Evaluation of
 
 Vigliensoni, Gabriel, et al. "Automatic Pitch Recognition in Printed Square-Note Notation." _12th International Society for Music Information Retrieval Conference_. Miami, 2011\. 423–428\. <[http://www.ismir2011.ismir.net/papers/PS3-12.pdf](http://www.ismir2011.ismir.net/papers/PS3-12.pdf)>. 
 
-Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recognition in Common Music Notation." _14th Society for Music Information Retrieval Conference_. Porto, Portugal, 2013\. 125–130\. <[http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf](http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf)>. 
+Vigliensoni, Gabriel, Gregory Burlet and Ichiro Fujinaga. "Optical Measure Recognition in Common Music Notation." _14th Society for Music Information Retrieval Conference_. Curitiba, Brazil, 2013\. 125–130\. <[http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf](http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf)>. 
 
 Weigl, David M. and Kevin R. Page. "Dynamic Semantic Notation: Jamming Together Music Encoding and Linked Data." _17th International Society for Music Information Retrieval Conference_. New York: International Society for Music Information Retrieval Conference, 2016\. Late-Breaking Session. <[https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf](https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf)>. 
 


### PR DESCRIPTION
This PR cleans up the MEI bibliography: http://music-encoding.org/resources/bibliography.html

Beside fixing typos and errors in bibliographical information and harmonizing the formatting, the changes requested include the following:
- provide stable and working (for now) links to papers whenever possible
- use global identifier (doi, urn) whenever possible
- point out the selectiveness of the list in the title
...
[ongoing]

fixes #11 