### PR TITLE
Removing broken links to acm.org

### DIFF
--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -26,6 +26,18 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
 }
 
 
+@article{Bohl_2011,
+ abstract = {},
+ author = {Bohl, Benjamin and Kepper, Johannes and Röwenstrunk, Daniel},
+ year = {2011},
+ title = {Perspektiven digitaler Musikeditionen aus der Sicht des Edirom-Projekts},
+ pages = {270–276},
+ volume = {5},
+ number = {3},
+ journal = {Die Tonkunst: Magazin f{\"u}r Klassische Musik und Musikwissenschaft}
+}
+
+
 @inproceedings{Burlet_2012,
  abstract = {This paper introduces Neon.js, a browser-based music notation editor written in JavaScript. The editor can be used to manipulate digitally encoded musical scores in square-note notation. This type of notation presents certain challenges to a music notation editor, since many neumes (groups of pitches) are ligatures–continuous graphical symbols that represent multiple notes. Neon.js will serve as a component within an online optical music recognition framework. The primary purpose of the editor is to provide a readily accessible interface to easily correct errors made in the process of optical music recognition. In this context, we envision an environment that promotes crowdsourcing to further the creation of editable and searchable online symbolic music collections and for generating and editing ground-truth data to train optical music recognition algorithms.},
  author = {Burlet, Gregory and Porter, Alastair and Hankinson, Andrew and Fujinaga, Ichiro},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -22,8 +22,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  booktitle = {DLfM 2016. Proceedings of the 3rd International Workshop on Digital Libraries for Musicology},
  year = {2016},
  address = {New York, NY},
- doi = {10.1145/2970044.2970053},
- url = {http://delivery.acm.org/10.1145/2980000/2970053/p33-bell.pdf}
+ doi = {10.1145/2970044.2970053}
 }
 
 
@@ -126,8 +125,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  booktitle = {DLfM 2016. Proceedings of the 3rd International Workshop on Digital Libraries for Musicology},
  year = {2016},
  address = {New York, NY},
- doi = {10.1145/2970044.2970052},
- url = {http://delivery.acm.org/10.1145/2980000/2970052/p1-devaney.pdf}
+ doi = {10.1145/2970044.2970052}
 }
 
 
@@ -213,7 +211,6 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  abstract = {In this paper we present our work towards developing a largescale web application for digitizing, recognizing (via optical music recognition), correcting, displaying, and searching printed music texts. We present the results of a recently completed prototype implementation of our workflow process, from document capture to presentation on the web. We discuss a number of lessons learned from this prototype. Finally, we present some open-source Web 2.0 tools developed to provide essential infrastructure components for making searchable printed music collections available online. Our hope is that these experiences and tools will help in creating next-generation globally accessible digital music libraries.},
  author = {Hankinson, Andrew and Burgoyne, John Ashley and Vigliensoni, Gabriel and Fujinaga, Ichiro},
  title = {Creating a Large-Scale Searchable Digital Collection from Printed Music Materials},
- url = {https://dl.acm.org/citation.cfm?id=2188221},
  pages = {903–908},
  publisher = {{Association for Computing Machinery}},
  booktitle = {WWW'12. Proceedings of the 21st International Conference Companion on World Wide Web},
@@ -323,8 +320,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  booktitle = {DLfM 2016. Proceedings of the 3rd International Workshop on Digital Libraries for Musicology},
  year = {2016},
  address = {New York, NY},
- doi = {10.1145/2970044.2970055},
- url = {http://delivery.acm.org/10.1145/2980000/2970055/p45-laplante.pdf}
+ doi = {10.1145/2970044.2970055}
 }
 
 
@@ -390,8 +386,7 @@ C'est {\`a} ce titre que la MEI montre une capacit{\'e} et une souplesse remarqu
  number = {7},
  issn = {0950-4125},
  journal = {Reference Reviews},
- doi = {10.1108/RR-03-2015-0073},
- url = {https://www.emeraldinsight.com/doi/pdfplus/10.1108/RR-03-2015-0073}
+ doi = {10.1108/RR-03-2015-0073}
 }
 
 
@@ -513,8 +508,7 @@ C'est {\`a} ce titre que la MEI montre une capacit{\'e} et une souplesse remarqu
  booktitle = {DLfM 2016. Proceedings of the 3rd International Workshop on Digital Libraries for Musicology},
  year = {2016},
  address = {New York, NY},
- doi = {10.1145/2970044.2970046},
- url = {http://delivery.acm.org/10.1145/2980000/2970046/p25-rizo.pdf}
+ doi = {10.1145/2970044.2970046}
 }
 
 
@@ -674,7 +668,7 @@ C'est {\`a} ce titre que la MEI montre une capacit{\'e} et une souplesse remarqu
  title = {{Ein XML-Datenformat zur Repr{\"a}sentation kritischer Musikedition unter besonderer Ber{\"u}cksichtigung von Neumennotation}},
  url = {http://www.dimused.uni-tuebingen.de/downloads/studienarbeit.pdf},
  note = {{Seminar Paper. T{\"u}bingen, Eberhard Karls Universit{\"a}t}},
- 
+
 }
 
 
@@ -794,8 +788,7 @@ The API was evaluated by: 1) creating an implementation of the API for documents
  booktitle = {DLfM 2016. Proceedings of the 3rd International Workshop on Digital Libraries for Musicology},
  year = {2016},
  address = {New York, NY},
- doi = {10.1145/2970044.2970056},
- url = {http://delivery.acm.org/10.1145/2980000/2970056/p57-viglianti.pdf}
+ doi = {10.1145/2970044.2970056}
 }
 
 
@@ -851,5 +844,3 @@ The API was evaluated by: 1) creating an implementation of the API for documents
  year = {2016},
  address = {Cambridge, UK}
 }
-
-

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -628,7 +628,6 @@ C'est {\`a} ce titre que la MEI montre une capacit{\'e} et une souplesse remarqu
  volume = {42},
  number = {4},
  journal = {Early Music},
- url_Link = {http://em.oxfordjournals.org/content/42/4/605.full.pdf+html},
  doi = {10.1093/em/cau098}
 }
 
@@ -702,7 +701,6 @@ C'est {\`a} ce titre que la MEI montre une capacit{\'e} et une souplesse remarqu
  author = {Stinson, John and Stoessel, Jason},
  year = {2014},
  title = {Encoding Medieval Music Notation for Research},
- url_Link = {http://em.oxfordjournals.org/content/42/4/613.full.pdf+html},
  pages = {613–617},
  volume = {42},
  number = {4},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -1,6 +1,6 @@
 % This file was created with Citavi 6.1.0.0
 % created 2018-05-05
-% modified 2018-06-06
+% modified 2018-06-22
 
 @inproceedings{Bell_2016,
  abstract = {Conductor copies of musical scores are typically rich in handwritten annotations. Ongoing archival efforts to digitize orchestral conductors' scores have made scanned copies of hundreds of these annotated scores available in digital formats.


### PR DESCRIPTION
This removes links to pdf files behind paywalls. Also one doubled doi link is removed. 