### PR TITLE
Update past conferences

### DIFF
--- a/conference/past.md
+++ b/conference/past.md
@@ -4,9 +4,9 @@ title: "Past Music Encoding Conferences"
 ---
 # Past Music Encoding Conferences
 
-## MEC2017, Tours, France
+## MEC2018, College Park, Maryland, USA
 
-Conference program 2017
+[Conference program 2018](2018ConferenceProgram.pdf "Music Encoding Conference Program 2018")
 
 ## MEC2017, Tours, France
 


### PR DESCRIPTION
This PR updates the past conferences to include the 2018 program, and removes a duplicate one for Tours.