### PR TITLE
removed 100% from toast

### DIFF
--- a/_sass/spectre/_toasts.scss
+++ b/_sass/spectre/_toasts.scss
@@ -6,7 +6,6 @@
   color: $light-color;
   display: block;
   padding: $layout-spacing;
-  width: 100%;
 
   &.toast-primary {
     @include toast-variant($primary-color);


### PR DESCRIPTION
Removes width attribute for toast to have it fixed at the top again. 
(We should discuss a better, more responsive approach in Oxford)