### PR TITLE
fix 2017 publications in bibliography

### DIFF
--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -3,18 +3,18 @@
 % modified 2018-06-22
 
 @incollection{behrendt_bain_helsen_2017,
-       publisher = {Books on Demand},
-          volume = {11},
-          author = {Inga Behrendt and Jennifer Bain and Kate Helsen},
-         address = {Norderstedt},
-           month = {July},
-          editor = {Hannah Busch and Franz Fischer and Patrick Sahle},
-           pages = {275--291},
-       booktitle = {Kodikologie und Pal{\"a}ographie im Digitalen Zeitalter 4 ? Codicology and Palaeography in the Digital Age 4},
-           title = {MEI Kodierung der fr{\"u}hesten Notation in linienlosen Neumen},
-            year = {2017},
-             url = {https://kups.ub.uni-koeln.de/7789/},
-        abstract = {Das Optical Neume Recognition Project (ONRP) hat die digitale Kodierung von musikalischen Notationszeichen aus dem Jahr um 1000 zum Ziel ? ein ambitioniertes Vorhaben, das die Projektmitglieder veranlasste, verschiedenste methodische Ans{\"a}tze zu evaluieren. Die Optical Music Recognition-Software soll eine linienlose Notation aus einem der {\"a}ltesten erhaltenen Quellen mit Notationszeichen, dem Antiphonar Hartker aus der Benediktinerabtei St. Gallen (Schweiz), welches heute in zwei B{\"a}nden in der Stiftsbibliothek in St. Gallen aufbewahrt wird, erfassen. Aufgrund der handgeschriebenen, linienlosen Notation stellt dieser Gregorianische Gesang den Forscher vor viele Herausforderungen. Das Werk umfasst {\"u}ber 300 verschiedene Neumenzeichen und ihre Notation, die mit Hilfe der Music Encoding Initiative (MEI) erfasst und beschrieben werden sollen. Der folgende Artikel beschreibt den Prozess der Adaptierung, um die MEI auf die Notation von Neumen ohne Notenlinien anzuwenden. Beschrieben werden Eigenschaften der Neumennotation, um zu verdeutlichen, wo die Herausforderungen dieser Arbeit liegen sowie die Funktionsweise des Classifiers, einer Art digitalen Neumenw{\"o}rterbuchs.}
+  publisher = {Books on Demand},
+  volume = {11},
+  author = {Inga Behrendt and Jennifer Bain and Kate Helsen},
+  address = {Norderstedt},
+  month = {July},
+  editor = {Hannah Busch and Franz Fischer and Patrick Sahle},
+  pages = {275--291},
+  booktitle = {Kodikologie und Pal{\"a}ographie im Digitalen Zeitalter 4 -- Codicology and Palaeography in the Digital Age 4},
+  title = {MEI Kodierung der fr{\"u}hesten Notation in linienlosen Neumen},
+  year = {2017},
+  url = {https://kups.ub.uni-koeln.de/7789/},
+  abstract = {Das Optical Neume Recognition Project (ONRP) hat die digitale Kodierung von musikalischen Notationszeichen aus dem Jahr um 1000 zum Ziel – ein ambitioniertes Vorhaben, das die Projektmitglieder veranlasste, verschiedenste methodische Ans{\"a}tze zu evaluieren. Die Optical Music Recognition-Software soll eine linienlose Notation aus einem der {\"a}ltesten erhaltenen Quellen mit Notationszeichen, dem Antiphonar Hartker aus der Benediktinerabtei St. Gallen (Schweiz), welches heute in zwei B{\"a}nden in der Stiftsbibliothek in St. Gallen aufbewahrt wird, erfassen. Aufgrund der handgeschriebenen, linienlosen Notation stellt dieser Gregorianische Gesang den Forscher vor viele Herausforderungen. Das Werk umfasst {\"u}ber 300 verschiedene Neumenzeichen und ihre Notation, die mit Hilfe der Music Encoding Initiative (MEI) erfasst und beschrieben werden sollen. Der folgende Artikel beschreibt den Prozess der Adaptierung, um die MEI auf die Notation von Neumen ohne Notenlinien anzuwenden. Beschrieben werden Eigenschaften der Neumennotation, um zu verdeutlichen, wo die Herausforderungen dieser Arbeit liegen sowie die Funktionsweise des Classifiers, einer Art digitalen Neumenw{\"o}rterbuchs.}
 }
 
 
@@ -286,15 +286,15 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
 }
 
 @inproceedings{kallionpaa_et_al_2017,
-booktitle = {New Interfaces for Musical Expression (NIME'17)},
-   month = {May},
-   title = {Composing and realising a game-like performance for disklavier and electronics},
+  booktitle = {NIME 2017: New Interfaces for Musical Expression, Copenhagen, 15--18 May 2017: Proceedings},
+  editor = {Erkut, Cumhur},
+  month = {May},
+  title = {Composing and Realising a Game-Like Performance for Disklavier and Electronics},
   author = {Maria Kallionp{\"a}{\"a} and Chris Greenhalgh and Adrian Hazzard and David M. Weigl and Kevin R. Page and Steve Benford},
-    year = {2017},
-   pages = {464--469},
-    note = {Published in: NIME 2017 : New Interfaces for Musical Expression, Copenhagen, 15-18 May 2017 : proceedings. Edited by Cumhur Erkut.},
-     url = {http://eprints.nottingham.ac.uk/44529/},
-abstract = {?Climb!? is a musical composition that combines the ideas of a classical virtuoso piece and a computer game. We present a case study of the composition process and realization of ?Climb!?, written for Disklavier and a digital interactive engine, which was co-developed together with the musical score. Specifically, the engine combines a system for recognising and responding to musical trigger phrases along with a dynamic digital score renderer. This tool chain allows for the composer?s original scoring to include notational elements such as trigger phrases to be automatically extracted to auto-configure the engine for live performance. We reflect holistically on the development process to date and highlight the emerging challenges and opportunities. For example, this includes the potential for further developing the workflow around the scoring process and the ways in which support for musical triggers has shaped the compositional approach.}
+  year = {2017},
+  pages = {464--469},
+  url = {http://eprints.nottingham.ac.uk/44529/},
+  abstract = {"Climb!" is a musical composition that combines the ideas of a classical virtuoso piece and a computer game. We present a case study of the composition process and realization of "Climb!", written for Disklavier and a digital interactive engine, which was co-developed together with the musical score. Specifically, the engine combines a system for recognising and responding to musical trigger phrases along with a dynamic digital score renderer. This tool chain allows for the composer's original scoring to include notational elements such as trigger phrases to be automatically extracted to auto-configure the engine for live performance. We reflect holistically on the development process to date and highlight the emerging challenges and opportunities. For example, this includes the potential for further developing the workflow around the scoring process and the ways in which support for musical triggers has shaped the compositional approach.}
 }
 
 
@@ -851,41 +851,38 @@ The API was evaluated by: 1) creating an implementation of the API for documents
  url = {http://ismir2013.ismir.net/wp-content/uploads/2013/09/207_Paper.pdf},
  pages = {125–130},
  editor = {{Souza Britto Jr., Alceu de} and Gouyon, Fabien and Dixon, Simon},
- booktitle = {Proceedings of the 14th International Society for Music Information Retrieval Conference, ISMIR 2013, Curitiba, Brazil, November 4-8, 2013},
+ booktitle = {Proceedings of the 14th International Society for Music Information Retrieval Conference, ISMIR 2013, Curitiba, Brazil, November 4–8, 2013},
  year = {2013}
 }
 
 @inproceedings{weigl_page_2017a,
-author="Weigl, David M.
-and Page, Kevin R.",
-editor="Blomqvist, Eva
-and Hose, Katja
-and Paulheim, Heiko
-and {\L}awrynowicz, Agnieszka
-and Ciravegna, Fabio
-and Hartig, Olaf",
-title="Dynamic Semantic Music Notation",
-booktitle="The Semantic Web: ESWC 2017 Satellite Events",
-year="2017",
-publisher="Springer International Publishing",
-address="Cham",
-pages="31--34",
-abstract="The Music Encoding Initiative (MEI) XML schema expresses musical structure addressing score elements at musically meaningful levels of granularity (e.g., individual systems, measures, or notes). While this provides a comprehensive representation of music content, only concepts and relationships provided by the MEI schema can be encoded. Here, we present our Music Encoding and Linked Data (MELD) framework which applies RDF Web Annotations to targetted portions of the MEI structure. Concepts and relationships from the Semantic Web can be included alongside MEI in an expanded musical knowledge graph. We have implemented a music performance scenario which collects, distributes, and displays semantic annotations, enhancing a digital musical score used by performers in a live music jam session.",
-isbn="978-3-319-70407-4"
+  author = {Weigl, David M. and Page, Kevin R.},
+  editor = {Blomqvist, Eva and Hose, Katja and Paulheim, Heiko and Lawrynowicz, Agnieszka and Ciravegna, Fabio and Hartig, Olaf},
+  title = {Dynamic Semantic Music Notation},
+  booktitle = {The Semantic Web: ESWC 2017 Satellite Events},
+  year = {2017},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages = {31--34},
+  abstract = {The Music Encoding Initiative (MEI) XML schema expresses musical structure addressing score elements at musically meaningful levels of granularity (e.g., individual systems, measures, or notes). While this provides a comprehensive representation of music content, only concepts and relationships provided by the MEI schema can be encoded. Here, we present our Music Encoding and Linked Data (MELD) framework which applies RDF Web Annotations to targetted portions of the MEI structure. Concepts and relationships from the Semantic Web can be included alongside MEI in an expanded musical knowledge graph. We have implemented a music performance scenario which collects, distributes, and displays semantic annotations, enhancing a digital musical score used by performers in a live music jam session.},
+  isbn = {978-3-319-70407-4},
+  url = {https://link.springer.com/content/pdf/10.1007%2F978-3-319-70407-4_7.pdf},
+  doi = {10.1007/978-3-319-70407-4_7}
 }
 
 @inproceedings{weigl_page_2017b,
+  abstract = {Music  notation  expresses  performance  instructions  in  a way commonly understood by musicians, but printed paper parts are limited to encodings of static, a priori knowledge. In  this  paper  we  present  a  platform  for  multi-way  communication  between  collaborating  musicians  through  the dynamic modification of digital parts:  the Music Encoding  and  Linked Data  (MELD)  framework  for distributed real-time annotation of digital music scores.  MELD users and software agents create semantic annotations of music concepts and relationships, which are associated with musical structure specified by the Music Encoding Initiative schema (MEI). Annotations are expressed in RDF, allowing alternative music vocabularies (e.g., popular vs.  classical music structures) to be applied.  The same underlying framework retrieves, distributes, and processes information that addresses semantically distinguishable music elements.  Further knowledge is incorporated from external sources through the use of Linked Data.  The RDF is also used to match annotation types and contexts to rendering actions which display the annotations upon the digital score.  Here, we present a MELD implementation and deployment which augments the digital music scores used by musicians in a group performance, collaboratively changing the sequence within and between pieces in a set list.},
   year = {2017},
   url = {https://ismir2017.smcnus.org/wp-content/uploads/2017/10/190_Paper.pdf},
-  publisher = {International Society for Music Information Retrieval},
-  title = {A framework for distributed semantic annotation of musical score: "Take it to the bridge!"},
+  title = {A Framework for Distributed Semantic Annotation of Musical Score: "Take it to the Bridge!"},
   author = {Weigl, David M. and Page, Kevin},
-  booktitle = {Proceedings of the 18th International Society for Music Information Retrieval Conference, ISMIR 2017, Suzhou, China, October 23-27, 2017},
+  booktitle = {Proceedings of the 18th International Society for Music Information Retrieval Conference, ISMIR 2017, Suzhou, China, October 23--27, 2017},
+  isbn = {978-981-11-5179-8}
 }
 
 
 @inproceedings{Weigl_2016,
- abstract = {The Music Encoding Initiative (MEI) [1] provides a framework for expressing musical notation that enables the identification (via XML identifiers), and thus addressing, of score elements at various levels of granularity (e.g. individual systems, measures, or notes) [2]. Verovio [3], an open-source MEI renderer that produces beautiful SVG renditions of the score, retains the MEI identifiers and element hierarchy in the produced output, enabling dynamic interactivity with score elements through a web browser. We present a demonstrator that combines these capabilities with semantic technologies including RDF, JSON-LD, SPARQL, and the Open Annotation data model, anchoring into the musical notation by using the MEI XML IDs as fragment identifiers to enable the fine-grained incorporation of musical notation within a web of Linked Data. This fusing of music and semantics affords the creation of rich Digital Music Objects supporting contemporary music consumption and performance.},
+ abstract = {The Music Encoding Initiative (MEI) provides a framework for expressing musical notation that enables the identification (via XML identifiers), and thus addressing, of score elements at various levels of granularity (e.g. individual systems, measures, or notes). Verovio, an open-source MEI renderer that produces beautiful SVG renditions of the score, retains the MEI identifiers and element hierarchy in the produced output, enabling dynamic interactivity with score elements through a web browser. We present a demonstrator that combines these capabilities with semantic technologies including RDF, JSON-LD, SPARQL, and the Open Annotation data model, anchoring into the musical notation by using the MEI XML IDs as fragment identifiers to enable the fine-grained incorporation of musical notation within a web of Linked Data. This fusing of music and semantics affords the creation of rich Digital Music Objects supporting contemporary music consumption and performance.},
  author = {Weigl, David M. and Page, Kevin},
  title = {Dynamic Semantic Notation. Jamming Together Music Encoding and Linked Data},
  url = {https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/08/weigl-dynamic.pdf},


### PR DESCRIPTION
This small PR cleans up the bibfile for MEI bibliography a bit by doing the following:
- fix some typos and formatting for 2017 publications
- add abstracts and links to PDF where possible