### PR TITLE
Fixed: Add community contacts page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ menu:
           - id: news
             label: 'News / Events'
             url: '/news-events.html'
-          - id: communitycontact
+          - id: communitycontacts
             label: 'Community Contacts'
             url: '/community-contacts.html'
           - id: interestgroups

--- a/_config.yml
+++ b/_config.yml
@@ -26,9 +26,9 @@ menu:
           - id: news
             label: 'News / Events'
             url: '/news-events.html'
-          - id: mailinglist
-            label: 'Mailing List'
-            url: '/mailing-list.html'
+          - id: communitycontact
+            label: 'Community Contacts'
+            url: '/community-contacts.html'
           - id: interestgroups
             label: 'Interest Groups'
             url: '/interest-groups.html'
@@ -97,4 +97,4 @@ sidemenu:
 collections:
   projects:
     output: true
-    permalink: /:collection/:name   
+    permalink: /:collection/:name

--- a/community/community-contacts.md
+++ b/community/community-contacts.md
@@ -15,7 +15,7 @@ Also, the archives of the list are open to the public and can be browsed online:
 
 # Slack channel
 
-MEI has a Slack team that is used for discussion, questions, announcements, and interest groups.
+MEI has a Slack channel that is used for discussion, questions, announcements, and collaboration, [https://music-encoding.slack.com](https://music-encoding.slack.com).
 
 To join, please fill in our [Slack Invitation Form](https://goo.gl/forms/cDWLuDgicFjXSENi2) and you will receive an invitation.
 

--- a/community/community-contacts.md
+++ b/community/community-contacts.md
@@ -1,7 +1,10 @@
 ---
 layout: default
-title: "Mailing list"
+title: "Contacting the Community"
+redirect_from:
+ - /community/mailing-list.html
 ---
+
 # Mailing list
 
 The official MEI mailing list, MEI-L, is used to inform the community about upcoming events, discuss possible improvements for MEI, evaluate encoding strategies and models, and get support from the full community. 
@@ -10,4 +13,11 @@ The list is open to anyone for subscription, and everyone is welcome to join MEI
 
 Also, the archives of the list are open to the public and can be browsed online: [https://lists.uni-paderborn.de/pipermail/mei-l/](https://lists.uni-paderborn.de/pipermail/mei-l/).
 
-Normally, there is not much traffic on the list, but the tone is friendly and most questions are answered within the first 24 hours. So if you have a particular question about MEI, please let others learn from your responses as well by asking there in public.
+# Slack channel
+
+MEI has a Slack team that is used for discussion, questions, announcements, and interest groups.
+
+To join, please fill in our [Slack Invitation Form](https://goo.gl/forms/cDWLuDgicFjXSENi2) and you will receive an invitation.
+
+Slack has [clients](https://slack.com/) for Mac, PC, Linux, and mobile devices, and may be used via any web browser.
+


### PR DESCRIPTION
Also redirects from the old mailing list page to the new community contacts page.