### PR TITLE
Update readme & schemas.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # The MEI Website
 
-This is the MEI website, available at [http://music-encoding.org](http://music-encoding.org).
+This is the MEI website, available at [https://music-encoding.org](https://music-encoding.org).
 
 For information about contributing and developing the website locally, please refer to the README of the MEI guidelines repository: https://github.com/music-encoding/guidelines

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # The MEI Website
 
 This is the MEI website, available at [http://music-encoding.org](http://music-encoding.org).
+
+For information about contributing and developing the website locally, please refer to the README of the MEI guidelines repository: https://github.com/music-encoding/guidelines

--- a/resources/schemas.md
+++ b/resources/schemas.md
@@ -16,3 +16,5 @@ The MEI Schemas are available at the following URLs:
  - MEI Mensural: [https://music-encoding.org/schema/4.0.0/mei-Mensural.rng](https://music-encoding.org/schema/4.0.0/mei-Mensural.rng)
  - MEI Neumes: [https://music-encoding.org/schema/4.0.0/mei-Neumes.rng](https://music-encoding.org/schema/4.0.0/mei-Neumes.rng)
  - MEI All (Any Start Element): [https://music-encoding.org/schema/4.0.0/mei-all_anyStart.rng](https://music-encoding.org/schema/4.0.0/mei-all_anyStart.rng)
+ 
+ A detailed overview of the changes for the MEI 4.0 schema is available here:  [https://music-encoding.org/archive/comparison-4.0.html](https://music-encoding.org/archive/comparison-4.0.html)

--- a/resources/schemas.md
+++ b/resources/schemas.md
@@ -11,7 +11,7 @@ The MEI Namespace is `http://www.music-encoding.org/ns/mei`
 
 The MEI Schemas are available at the following URLs:
 
- - MEI All: [https://music-encoding.org/schema/4.0.0/mei-all.rng](https://music-encoding.org/sch`ema/4.0.0/mei-all.rng)
+ - MEI All: [https://music-encoding.org/schema/4.0.0/mei-all.rng](https://music-encoding.org/schema/4.0.0/mei-all.rng)
  - MEI CMN: [https://music-encoding.org/schema/4.0.0/mei-CMN.rng](https://music-encoding.org/schema/4.0.0/mei-CMN.rng)
  - MEI Mensural: [https://music-encoding.org/schema/4.0.0/mei-Mensural.rng](https://music-encoding.org/schema/4.0.0/mei-Mensural.rng)
  - MEI Neumes: [https://music-encoding.org/schema/4.0.0/mei-Neumes.rng](https://music-encoding.org/schema/4.0.0/mei-Neumes.rng)


### PR DESCRIPTION
This small PR adds a link to the MEI guidelines repository to provide information on how to contribute and on how to run the website locally for development. 

It also adds a link from schemas page to the comparison page for the MEI 4.0 schema. In passing it fixes a broken link in schemas.md to the MEI ALL schema.

Fixes #51 
Fixes #53




