### PR TITLE
Tutorials: Add more information to tutorial entry page

### DIFF
--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -19,6 +19,17 @@ layout: default
                 tutorial, which will provide backgrounds about the necessary steps. Please also have a look at our list
                 of missing tutorials on <a href="https://github.com/music-encoding/music-encoding.github.io/issues/88" target="_blank" rel="noopener, noreferrer">Github</a>.</p>
 
+
+            <h3>External tutorials & related material</h3>
+            <ul>
+                <li>
+                    Kijas, Anna, & Viglianti, Raffaele (2019). <strong>Introduction to the Music Encoding Initiative.</strong> <i>#DLFTeach Toolkit: Lesson Plans for Digital Library Instruction</i>. 1st ed. <a href="https://doi.org/10.21428/65a6243c.9fa9b4f7" target="_blank" rel="noopener, noreferrer">https://doi.org/10.21428/65a6243c.9fa9b4f7</a>
+                </li>
+                <li>
+                    TEI Music SIG (2012). <strong>TEI with Music Notation.</strong> <a href="https://web.archive.org/web/20130306003734/https://tei-c.org/SIG/Music/twm/index.html" target="_blank" rel="noopener, noreferrer">https://web.archive.org/web/20130306003734/https://tei-c.org/SIG/Music/twm/index.html</a>
+                </li>
+            </ul>
+
         {% else %}
 
             <h2>{{ page.fullname }}</h2>

--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -7,10 +7,17 @@ layout: default
         {% if page.type != 'tutorial' %}
             <h2>MEI Tutorials</h2>
             <p>On this page, you'll find a number of small tutorials for MEI,
-                each of them introducing a specific feature. If
-                you're about to start learning MEI, we recommend to start with
-                the 5 minute Quickstart tutorial, which will let you encode
-                a very simple melody with MEI.</p>
+                each of them introducing a specific feature.</p>
+
+            <p>If you're about to start learning MEI, we recommend to start with the
+                <a href="/tutorials/101-quickstart.html" target="_blank" rel="noopener, noreferrer">5 minute Quickstart</a>
+                tutorial, which will let you encode a very simple melody with MEI.</p>
+
+
+            <p>If you're about to write a new MEI tutorial, we recommend to start with the
+                <a href="/tutorials/tutorials.html" target="_blank" rel="noopener, noreferrer">Writing tutorials</a>
+                tutorial, which will provide backgrounds about the necessary steps. Please also have a look at our list
+                of missing tutorials on <a href="https://github.com/music-encoding/music-encoding.github.io/issues/88" target="_blank" rel="noopener, noreferrer">Github</a>.</p>
 
         {% else %}
 

--- a/_tutorials/199_tutorials/writingTutorials-06.html
+++ b/_tutorials/199_tutorials/writingTutorials-06.html
@@ -6,7 +6,7 @@
         and ask for reviews by some of the Technical Team.
         Of course, we're happy to assist you – just <a href="/community/community-contacts.html" target="_blank">contact</a> us.
         To get a headstart, you may want to copy an existing tutorial and modify that to your needs. The 
-        <code>101_quickstart</code> tutorial should be a good starting poing, as it is very simple, but still holds all relevant
+        <code>101_quickstart</code> tutorial should be a good starting point, as it is very simple, but still holds all relevant
         features. 
     </p>
     <p>


### PR DESCRIPTION
This PR adds some more information to the tutorial entry page. It adds a paragraph about writing tutorials and where to find a list of missing tutorials. It also adds external tutorials and training material related to MEI.

