### PR TITLE
Bibliography: Add bibliography entries

### DIFF
--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -21,14 +21,14 @@ layout: default
 
 
             <h3>External tutorials & related material</h3>
-            <ul>
-                <li>
-                    Kijas, Anna, & Viglianti, Raffaele (2019). <strong>Introduction to the Music Encoding Initiative.</strong> <i>#DLFTeach Toolkit: Lesson Plans for Digital Library Instruction</i>. 1st ed. <a href="https://doi.org/10.21428/65a6243c.9fa9b4f7" target="_blank" rel="noopener, noreferrer">https://doi.org/10.21428/65a6243c.9fa9b4f7</a>
-                </li>
-                <li>
-                    TEI Music SIG (2012). <strong>TEI with Music Notation.</strong> <a href="https://web.archive.org/web/20130306003734/https://tei-c.org/SIG/Music/twm/index.html" target="_blank" rel="noopener, noreferrer">https://web.archive.org/web/20130306003734/https://tei-c.org/SIG/Music/twm/index.html</a>
-                </li>
-            </ul>
+            <!--
+            to add an entry to this list,
+            create another entry in ./resources/mei_bibliography.bib
+            with "keywords = {tutorial}"
+            -->
+            <div>
+                <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmaster%2Fresources%2Fmei_bibliography.bib&authorFirst=1&nocache=1&jsonp=1&filter=keywords:tutorial"></script>
+            </div>
 
         {% else %}
 

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -1,6 +1,6 @@
 % This file was created with Citavi 6.1.0.0
 % created 2018-05-05
-% modified 2018-06-22
+% modified 2019-10-27
 
 @incollection{behrendt_bain_helsen_2017,
   publisher = {Books on Demand},
@@ -348,6 +348,18 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  url_URN = {http://nbn-resolving.de/urn:nbn:de:hbz:38-66395},
  isbn = {9783844800760}
 
+}
+
+@incollection{Kijas_2019,
+ abstract = {In this tutorial, we provide an introduction to encoding music documents according to the Music Encoding Initiative (MEI) for people engaged in digital library work. The MEI is a community-driven effort to create an open source representation of music notation in a machine readable structure. While there are a number of different formats in use for marking up or encoding music, including MusicXML, Humdrum, and Plaine & Easie, the focus of this tutorial is on applying the MEI guidelines (version 3.0.0). These guidelines present a core set of rules for the representation of symbolic, physical, and intellectual aspects of music notation expressed using an XML schema.},
+ author = {Kijas, Anna and Viglianti, Raff},
+ title = {Introduction to the Music Encoding Initiative},
+ publisher = {PubPub},
+ editor = {Rodrigues, Liz and Pappas, Erin and Rowell, Chelcie and Shorish, Yasmeen},
+ booktitle = {{\#}DLFTeach Toolkit: Lesson Plans for Digital Library Instruction},
+ year = {2019},
+ doi = {10.21428/65a6243c.9fa9b4f7},
+ keywords = {tutorial}
 }
 
 
@@ -830,6 +842,19 @@ journal = {Die Musikforschung}
  volume = {61},
  number = {1},
  journal = {Fontes Artis Musicae}
+}
+
+
+@misc{TEIMusicSIG_2012,
+ abstract = {As part of a project funded by the TEI, the group focussed on using TEI's One Document Does it all (ODD) vocabulary to connect the TEI to music encoding formats. Specifically, first efforts concentrated on the Music Encoding Initiative (MEI) format. Therefore, these guidelines describe a TEI-with-MEI customisation that uses the TEI element <notatedMusic> to embed encode music notation.
+The examples in these guidelines present typical occurrences of music within written text. They are taken from a handful of documents that we believe demonstrate the need for the inclusion of encoded music notation within TEI-encoded texts. See the bibliography for more information.
+All the music examples are encoded using MEI; however, it is possible to use <notatedMusic> to link to external representations of music in any other format. See below for an example.
+These guidelines do not claim to be comprehensive; however, we present them with the hope of encouraging further testing, improvement, and widespread use of this customisation.},
+ author = {{TEI Music SIG}},
+ year = {2012},
+ title = {{TEI with Music Notation}},
+ url = {https://web.archive.org/web/20130306003734/https://tei-c.org/SIG/Music/twm/index.html},
+ keywords = {tutorial}
 }
 
 


### PR DESCRIPTION
This PR adds the two MEI tutorials mentioned on the tutorials page to the MEI bibliography.

It also replaces the manual list on the tutorials page with a filtered version of the bibliography that only includes the tutorial entries. Generated in this way, the entries do not have to be maintained in two different places.