### PR TITLE
style(tutorials): use theme=side for bibbase style and move content to md file

### DIFF
--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -5,30 +5,8 @@ layout: default
     <div class="column col-8 tutorialBox">
 
         {% if page.type != 'tutorial' %}
-            <h2>MEI Tutorials</h2>
-            <p>On this page, you'll find a number of small tutorials for MEI,
-                each of them introducing a specific feature.</p>
 
-            <p>If you're about to start learning MEI, we recommend to start with the
-                <a href="/tutorials/101-quickstart.html" target="_blank" rel="noopener, noreferrer">5 minute Quickstart</a>
-                tutorial, which will let you encode a very simple melody with MEI.</p>
-
-
-            <p>If you're about to write a new MEI tutorial, we recommend to start with the
-                <a href="/tutorials/tutorials.html" target="_blank" rel="noopener, noreferrer">Writing tutorials</a>
-                tutorial, which will provide backgrounds about the necessary steps. Please also have a look at our list
-                of missing tutorials on <a href="https://github.com/music-encoding/music-encoding.github.io/issues/88" target="_blank" rel="noopener, noreferrer">Github</a>.</p>
-
-
-            <h3>External tutorials & related material</h3>
-            <!--
-            to add an entry to this list,
-            create another entry in ./resources/mei_bibliography.bib
-            with "keywords = {tutorial}"
-            -->
-            <div>
-                <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmaster%2Fresources%2Fmei_bibliography.bib&authorFirst=1&nocache=1&jsonp=1&filter=keywords:tutorial"></script>
-            </div>
+            {{ content }}
 
         {% else %}
 

--- a/resources/tutorials.md
+++ b/resources/tutorials.md
@@ -5,7 +5,18 @@ title: "MEI Tutorials"
 # MEI Tutorials
 
 On this page, you'll find a number of small tutorials for MEI, 
-each of them introducing a specific feature. If
-you're about to start learning MEI, we recommend to start with
-the 5 minute Quickstart tutorial, which will let you encode
-a very simple melody with MEI. 
+each of them introducing a specific feature. 
+
+If you're about to start learning MEI, we recommend to start with the [5 minute Quickstart](/tutorials/101-quickstart) tutorial, which will let you encode a very simple melody with MEI.
+
+If you're about to write a new MEI tutorial, we recommend to start with the [Writing tutorials](/tutorials/tutorials) tutorial, which will provide backgrounds about the necessary steps. Please also have a look at our list of missing tutorials on [Github](https://github.com/music-encoding/music-encoding.github.io/issues/88).
+ 
+### External tutorials & related material
+ 
+{% comment %}
+to add an entry to this list, 
+create another entry in ./resources/mei_bibliography.bib
+with "keywords = {tutorial}"
+{% endcomment %}
+ 
+<script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmaster%2Fresources%2Fmei_bibliography.bib&authorFirst=1&nocache=1&jsonp=1&theme=side&filter=keywords:tutorial"></script>


### PR DESCRIPTION
This PR changes the style for the bibbase generated list of external tutorials on the Tutorials entry page from default to `side` which is more compact.

It also moves the content of the page from `_layout/tutorials.html` to the corresponding `resource/tutorials.md` file, which is then called from the html file via `{{ content }}`