### PR TITLE
Add announcement of event.

### DIFF
--- a/_posts/2020-05-23-digital-humanities-series-sessionII.md
+++ b/_posts/2020-05-23-digital-humanities-series-sessionII.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title:  "Digital Humanities in Early Music Research I - Session II: Early Music Databases and Encoding"
+date:   2020-05-23 22:45:00
+categories: update
+---
+
+A free, open to the public, series of conferences and workshops focusing on the use of digital humanities in early music research will be offered online at the end of June. The Session II of the Digital Humanities in Early Music Research I series will focus on databases and encoding of early music. 
+
+Led by two members of the Music Encoding Initiative Board, Elsa de Luca (administrative chair) and Martha E. Thomae, Session II will consist of two presentations and two workshops (see the following program). **Reservation is required**, please contact the coordinator Jana Franková ([frankova@mua.cas.cz](frankova@mua.cas.cz)) and Hana Vlhová-Wörmer ([vlhova@mua.cas.cz](vlhova@mua.cas.cz)) jointly to reserve your place.
+
+**Presentation I: The Portuguese Early Music Database**
+
+*Monday, June 22nd, 16–17h (GMT+2)*
+
+This presentation introduces a large project on Digital Humanities started about ten years ago by Manuel Pedro Ferreira at the NOVA University of Lisbon. The [Portuguese Early Music Database](http://pemdatabase.eu/) is a digital library of Iberian (mainly Portuguese) manuscripts with musical notation written before c. 1650. In PEM, every manuscript is given in full-color reproduction accompanied by a codicological description. Additionally, the musical contents of all fragments—and a selection of codices with monophonic or polyphonic music as well—are fully indexed. Crucially, plainchant in PEM is indexed following the [Cantus Index](http://cantusindex.org/) system and, as such, the PEM Database is connected to other international medieval music databases by means of unique Cantus ID numbers. I will discuss the search capabilities of PEM, its contents, and all the challenges related to the development and implementation of such a unique project in early music.
+
+**Workshop I: Introduction to MEI**
+
+*Wednesday, June 24th, 16–19h15 (GMT+2)*
+
+General introduction to MEI (Music Encoding Initiative) and the elements and attributes of the Neumes and Mensural modules.
+
+**Presentation II: MEI for Encoding Mensural Music – A Survey**
+
+*Monday, June 29th, 16–17h (GMT+2)*
+
+A peculiarity of mensural notation is the context-dependent nature of the duration of the notes. Mensural pieces are commonly written in separate parts, a layout that does not allow us to visualize the vertical sonorities and appreciate the polyphonic texture of the piece. Although many mensural pieces are encoded in symbolic formats (e.g., MusicXML and MIDI), these files tend to encode the modern transcription of the piece rather than its original (mensural) values. MEI, instead, allows encoding mensural music in the original notation through its Mensural Module. This presentation showcases some projects that have worked on encoding mensural music in MEI. The common goal of these projects is to present the mensural pieces as scores in the original notation. The MEI representation allows visualizing the vertical sonorities (which are hindered by the separate-parts layout of the original sources) while still maintaining the notation of the sources, thus avoiding to lose some important details of the notation in modern transcriptions.
+
+**Workshop II: Hands-on MEI Encoding**
+
+*Tuesday, June 30th, 16–19h15 (GMT+2)*
+
+Presentation of MEI encoding for chant and mensural notations from different areas of Western Europe. Followed by an open discussion of coding examples of the Jistebnický kancionál manuscript.


### PR DESCRIPTION
Digital Humanities in Early Music Research I, Session II: Early Music Databases and Encoding to be held in June 2020.