### PR TITLE
Remove global future:true option

### DIFF
--- a/_conferences/2013/index.html
+++ b/_conferences/2013/index.html
@@ -4,7 +4,7 @@ sidemenu: conference
 title: "Music Encoding Conference 2013"
 subtitle: "Concepts, Methods, Editions"
 venue: "Mainz Academy for Literature and Sciences, Mainz, Germany"
-date: 2013-05-22
+date-start: 2013-05-22
 date-end: 2013-05-24
 permalink: "/conference/2013/"
 tag: MEC2013

--- a/_conferences/2014/index.html
+++ b/_conferences/2014/index.html
@@ -4,7 +4,7 @@ sidemenu: conference
 title: "Music Encoding Conference 2014"
 subtitle: ""
 venue: "University of Virginia, Charlottesville, MD, USA"
-date: 2014-05-20
+date-start: 2014-05-20
 date-end: 2014-05-23
 permalink: "/conference/2014/"
 tag: MEC2014

--- a/_conferences/2015/index.html
+++ b/_conferences/2015/index.html
@@ -4,7 +4,7 @@ sidemenu: conference
 title: "Music Encoding Conference 2015"
 subtitle: "TERZO CONVEGNO INTERNAZIONALE SULLA CODIFICA DIGITALE DELLA MUSIC"
 venue: "Biblioteca Umanistica – Università degli Studi, Firenze, Italia"
-date: 2015-05-18
+date-start: 2015-05-18
 date-end: 2015-05-21
 permalink: "/conference/2015/"
 tag: MEC2015

--- a/_conferences/2016/index.html
+++ b/_conferences/2016/index.html
@@ -4,7 +4,7 @@ sidemenu: conference
 title: "Music Encoding Conference 2016"
 subtitle: ""
 venue: "Schulich School of Music, McGill Univerity Montréal, Québec, Canada"
-date: 2016-05-17
+date-start: 2016-05-17
 date-end: 2016-05-20
 permalink: "/conference/2016/"
 tag: MEC2016

--- a/_conferences/2017/index.html
+++ b/_conferences/2017/index.html
@@ -4,7 +4,7 @@ sidemenu: conference
 title: "Music Encoding Conference 2017"
 subtitle: ""
 venue: "Centre d’études supérieures de la Renaissance (CESR) – University of Tours, Tours, France"
-date: 2017-05-16
+date-start: 2017-05-16
 date-end: 2017-05-19
 permalink: "/conference/2017/"
 tag: MEC2017

--- a/_conferences/2018/index.html
+++ b/_conferences/2018/index.html
@@ -5,7 +5,7 @@ title: "Music Encoding Conference 2018"
 subtitle: "Encoding and Performance"
 venue: "University of Maryland, College Park, MD, USA"
 image: conference/2018/mec2018dates.jpg
-date: 2018-05-22
+date-start: 2018-05-22
 date-end: 2018-05-25
 permalink: "/conference/2018/"
 tag: MEC2018

--- a/_conferences/2019/index.html
+++ b/_conferences/2019/index.html
@@ -5,7 +5,7 @@ title: "Music Encoding Conference 2019"
 subtitle: ""
 venue: "University of Vienna – Department of Musicology, Vienna, Austria"
 image: conference/2019/mec2019dates.jpg
-date: 2019-05-29
+date-start: 2019-05-29
 date-end: 2019-06-01
 permalink: "/conference/2019/"
 tag: MEC2019

--- a/_conferences/2020/index.html
+++ b/_conferences/2020/index.html
@@ -5,7 +5,7 @@ title: "Music Encoding Conference 2020"
 subtitle: ""
 venue: "Tufts University, Medford, MA, USA"
 image: conference/2020/MEC4.jpg
-date: 2020-05-26
+date-start: 2020-05-26
 date-end: 2020-05-29
 permalink: "/conference/2020/"
 tag: MEC2020

--- a/_conferences/2021/index.html
+++ b/_conferences/2021/index.html
@@ -5,7 +5,7 @@ title: "Music Encoding Conference 2021"
 subtitle: ""
 venue: "Universidad de Alicante, Spain"
 image: conference/2021/MEC.jpg
-date: 2021-05-25
+date-start: 2021-05-25
 date-end: 2021-05-28
 redirect_from: /community/conference/
 redirect_from: /conference/

--- a/_config.yml
+++ b/_config.yml
@@ -13,9 +13,6 @@ repository: "music-encoding/music-encoding.github.io"
 plugins:
   - jekyll-redirect-from
 
-# Allow documents with dates in the future (upcoming conferences, events)
-future: true
-
 menu:
     - id: about
       label: 'About'

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -10,9 +10,9 @@ layout: default
       {% if page.subtitle != "" %}
         <h2 style="font-style: italic;">{{ page.subtitle }}</h2>
       {% endif %}
-      <h2 style="font-style: italic;">{{ page.date | date_to_long_string }} to {{ page.date-end | date_to_long_string }}</h2>
+      <h2 style="font-style: italic;">{{ page.date-start | date_to_long_string }} to {{ page.date-end | date_to_long_string }}</h2>
       <h2 style="font-style: italic;">{{ page.venue }}</h2>
-      <div><a class="btn btn-primary" href="/conference/{{ page.date | date: "%Y" }}
+      <div><a class="btn btn-primary" href="/conference/{{ page.date-start | date: "%Y" }}
 ConferenceProgram.pdf" target="_blank">Download as PDF</a></div>
     {% else %}
       <div class="dropdown col-sm-1 show-sm">


### PR DESCRIPTION
As discussed in #162 , this PR removes the `future:true` option introduced in https://github.com/music-encoding/music-encoding.github.io/pull/163/commits/eaeb9ee6af7824d58e93b3b9e9eb3ca6432ea20f.

Instead, `future:false` (Jekyll's default) is used, so that post messages are intuitively posted only at their specified time without any need for additional options. 

The front matter of the conference index files now uses `date-start` instead of `date` for the start date of the conference, so it is not affected by Jekylls internal blog-specific date handling. Thus, future conferences will show up if needed. 

If it is necessary to hide (recent or future) conference files, it is possible to use the option `published: false` in the front matter of that file individually.