### PR TITLE
Style improvements

### DIFF
--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -4,7 +4,7 @@ layout: default
 
 {% assign menu = site.conferences | where:"tag",page.tag %}
 <div class="columns">
-  <div class="column col-10 col-sm-11">
+  <div class="column col-10 col-sm-12">
     {% if content == "" %}
       <h1>{{ page.title }}</h1>
       {% if page.subtitle != "" %}

--- a/_sass/mei.scss
+++ b/_sass/mei.scss
@@ -1,11 +1,13 @@
 @import "specs";
-/*
-    Sticky footer
-*/
+
 body {
+    /* Sticky footer */
     display: flex;
     min-height: 100vh;
     flex-direction: column;
+    /* Padding correction for bibbase */
+    padding-left:inherit;
+    padding-right:inherit
 }
 
 .content {


### PR DESCRIPTION
This PR fixes the wrong padding on pages with bib-base inclusion as mentioned in #140. 

Due to bootstrap involvement, these pages get an additional `padding-left:20px; padding-right:20px`, which is removed here by applying `padding-left:inherit; padding-right:inherit` on the `body` element. No side effects have been observed, all pages are displayed as expected. 

Additionally, this PR changes the content width of the conference section on small devices from `col-sm-11` to full-width `col-sm-12` (similar to other contents).

Fixes #140 