### PR TITLE
Fix title for Rizo's entry

### DIFF
--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -611,7 +611,7 @@ In this context, this Ph.D. dissertation aims to develop a theoretical model for
 @article{Rizo_2019,
 abstract = {We propose a standard representation for hierarchical musical analyses as an extension to the Music Encoding Initiative (MEI) representation for music. Analyses of music need to be represented in digital form for the same reasons as music: preservation, sharing of data, data linking, and digital processing. Systems exist for representing sequential information, but many music analyses are hierarchical, whether represented explicitly in trees or graphs or not. Features of MEI allow the representation of an analysis to be directly associated with the elements of the music analyzed. MEI’s basis in TEI (Text Encoding Initiative), allows us to design a scheme which reuses some of the elements of TEI for the representation of trees and graphs. In order to capture both the information specific to a type of music analysis and the underlying form of an analysis as a tree or graph, we propose related “semantic” encodings, which capture the detailed information, and generic “non-semantic” encodings which expose the tree or graph structure. We illustrate this with examples of representations of a range of different kinds of analysis.},
 author = {Rizo, David and Marsden, Alan},
-title = {Encoding music performance data in Humdrum and MEI},
+title = {An MEI-based standard encoding for hierarchical music analyses},
 pages = {93–105},
 volume = {20},
 number = {1},


### PR DESCRIPTION
Issue with Rizo and Marsden (2019) entry in the [website's bibliography](https://music-encoding.org/resources/bibliography.html ). The title was wrong, it was actually the one from Devaney and Léveillé (2019). It has been corrected now to "An MEI-based standard encoding for hierarchical music analysis."