### PR TITLE
Add 'organizers' section for past conferences.

### DIFF
--- a/_conferences/2013/committee.html
+++ b/_conferences/2013/committee.html
@@ -1,0 +1,25 @@
+---
+layout: conference
+title: "Organizers"
+permalink: "/conference/2013/committee/"
+tag: MEC2013
+id: committee
+---
+
+<div class="mec2013-page" style="margin-top:2em;">
+    <h2>Local Organizing Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Johannes Kepper, Universität Paderborn</span></li>
+        <li><span style="font-weight: 400;">Daniel Röwenstrunk, Universität Paderborn</span></li>
+        <li><span style="font-weight: 400;">Perry Roland, University of Virginia</span></li>
+    </ul>
+    
+    <h2>Program Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Ichiro Fujinaga (Committee Chair), McGill University, Montreal</span></li>
+        <li><span style="font-weight: 400;">Niels Krabbe, Det Kongelige Bibliotek, København</span></li>
+        <li><span style="font-weight: 400;">Elena Pierazzo, King's College, London</span></li>
+        <li><span style="font-weight: 400;">Eleanor Selfridge-Field, CCARH, Stanford</span></li>
+        <li><span style="font-weight: 400;">Joachim Veit, Universität Paderborn, Detmold</span></li>
+    </ul>
+</div>

--- a/_conferences/2014/committee.html
+++ b/_conferences/2014/committee.html
@@ -1,0 +1,26 @@
+---
+layout: conference
+title: "Organizers"
+permalink: "/conference/2014/committee/"
+tag: MEC2014
+id: committee
+---
+
+<div class="mec2014-page" style="margin-top:2em;">
+    <h2>Local Organizing Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Perry Roland, University of Virginia</span></li>        
+        <li><span style="font-weight: 400;">Sarah Wells, University of Virginia</span></li>
+        <li><span style="font-weight: 400;">Johannes Kepper, Universität Paderborn</span></li>
+        <li><span style="font-weight: 400;">Daniel Röwenstrunk, Universität Paderborn</span></li>
+    </ul>
+
+    <h2>Program Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Giuliano Di Bacco (Committee Chair), Indiana University</span></li>
+        <li><span style="font-weight: 400;">Richard Freedman, Haverford College</span></li>
+        <li><span style="font-weight: 400;">Ichiro Fujinaga, McGill University, Montreal</span></li>
+        <li><span style="font-weight: 400;">Laurent Pugin, RISM Switzerland</span></li>
+        <li><span style="font-weight: 400;">Christine Siegert, Universität der Künste, Berlin</span></li>
+    </ul>
+</div>

--- a/_conferences/2015/committee.html
+++ b/_conferences/2015/committee.html
@@ -1,0 +1,28 @@
+---
+layout: conference
+title: "Organizers"
+permalink: "/conference/2015/committee/"
+tag: MEC2015
+id: committee
+---
+
+<div class="mec2015-page" style="margin-top:2em;">
+    <h2>Local Organizing Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Giuliano Di Bacco (Committee Co-Chair), Indiana University Bloomington, USA</span></li>
+        <li><span style="font-weight: 400;">Federica Riva (Committee Co-Chair), IAML-Italia / Conservatorio di musica “L. Cherubini” di Firenze</span></li>
+        <li><span style="font-weight: 400;">Mila De Santis, Università di Firenze</span></li>
+        <li><span style="font-weight: 400;">Paola Gibbin, Biblioteca Nazionale di Firenze</span></li>
+        <li><span style="font-weight: 400;">Johannes Kepper, Musikwissenschaftliches Seminar Detmold/Paderborn, Germany</span></li>
+        <li><span style="font-weight: 400;">Perry Roland, University of Virginia, USA</span></li>
+    </ul>
+
+    <h2>Program Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Christine Siegert (Committee Chair), Universität der Künste Berlin, Germany</span></li>
+        <li><span style="font-weight: 400;">Stephen Downie, University of Illinois at Urbana-Champaign, USA</span></li>
+        <li><span style="font-weight: 400;">Richard Freedman, Haverford College, USA</span></li>
+        <li><span style="font-weight: 400;">Axel Teich Geertinger, The Royal Library, Copenhagen, Denmark</span></li>
+        <li><span style="font-weight: 400;">Franz Kelnreiter, Internationale Stiftung Mozarteum Salzburg, Austria</span></li>
+    </ul>
+</div>

--- a/_conferences/2016/committee.html
+++ b/_conferences/2016/committee.html
@@ -1,0 +1,29 @@
+---
+layout: conference
+title: "Organizers"
+permalink: "/conference/2016/committee/"
+tag: MEC2016
+id: committee
+---
+
+<div class="mec2016-page" style="margin-top:2em;">
+    <h2>Local Organizing Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Ichiro Fujinaga (Committee Co-Chair), Schulich School of Music, McGill University</span></li>
+        <li><span style="font-weight: 400;">Andrew Hankinson (Committee Co-Chair), Schulich School of Music, McGill University</span></li>
+        <li><span style="font-weight: 400;">Ryan Bannon, Schulich School of Music, McGill University</span></li>
+        <li><span style="font-weight: 400;">Karen Desmond, Schulich School of Music, McGill University</span></li>
+        <li><span style="font-weight: 400;">Emily Hopkins, Schulich School of Music, McGill University</span></li>
+        <li><span style="font-weight: 400;">Audrey Laplante, Université de Montréal</span></li>
+        <li><span style="font-weight: 400;">Laura Risk, Schulich School of Music, McGill University</span></li>
+    </ul>
+
+    <h2>Program Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Franz Kelnreiter (Committee Chair), Internationale Stiftung Mozarteum Salzburg, Austria / Digitale Mozart-Edition</span></li>
+        <li><span style="font-weight: 400;">Richard Chesser, British Library, London, UK</span></li>
+        <li><span style="font-weight: 400;">Eleanor Selfridge-Field, CCARH, Stanford University, USA</span></li>
+        <li><span style="font-weight: 400;">Peter Stadler, Carl-Maria-von-Weber-Gesamtausgabe, Germany</span></li>
+        <li><span style="font-weight: 400;">Raffaele Viglianti, University of Maryland, USA</span></li>
+    </ul>
+</div>

--- a/_conferences/2017/committee.html
+++ b/_conferences/2017/committee.html
@@ -1,0 +1,28 @@
+---
+layout: conference
+title: "Organizers"
+permalink: "/conference/2017/committee/"
+tag: MEC2017
+id: committee
+---
+
+<div class="mec2017-page" style="margin-top:2em;">
+    <h2>Local Organizing Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Philippe Vendrix (Committee Co-Chair), Centre d’études supérieures de la Renaissance (CESR), Université de Tours</span></li>
+        <li><span style="font-weight: 400;">Philippe Rigaux (Committee Co-Chair), Conservatoire national des arts et métiers (CNAM), Paris</span></li>
+        <li><span style="font-weight: 400;">Vincent Besson, CESR, Université de Tours</span></li>
+        <li><span style="font-weight: 400;">Hyacinthe Belliot, CESR, Université de Tours</span></li>
+        <li><span style="font-weight: 400;">Alice Loffredo-Nué, CESR, Université de Tours</span></li>
+        <li><span style="font-weight: 400;">Jean-Louis Bouteiller, CESR, Université de Tours</span></li>
+    </ul>
+    
+    <h2>Program Committee</h4>
+    <ul>
+        <li><span style="font-weight: 400;">Richard Chesser (Committee Chair), British Library, London, UK</span></li>
+        <li><span style="font-weight: 400;">Laurent Pugin, RISM Switzerland, Bern</span></li>
+        <li><span style="font-weight: 400;">John Rink, University of Cambridge, UK</span></li>
+        <li><span style="font-weight: 400;">Karen Desmond, Brandeis University, USA</span></li>
+        <li><span style="font-weight: 400;">David Rizo Valero, University of Alicante, Spain</span></li>
+    </ul>
+</div>


### PR DESCRIPTION
The 'organizers' section is on the side menu, it includes entries for the local organizing committee and the program committee. This is just for the conferences that do not have images (2013–2017), the others (2018–2020) already include this information in the call for proposals.