### PR TITLE
Add missing news post for postponed MEC2021

### DIFF
--- a/_posts/2020-12-18-MEC2021-update..md
+++ b/_posts/2020-12-18-MEC2021-update..md
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "MEC2021 postponed to July 2021"
+date:   2020-12-18 12:00:00
+categories: update
+---
+Dear MEI community,
+
+With the COVID-19 pandemic still not under control, it currently remains uncertain whether travelling in May would be safe enough for everyone. The various vaccines, among other factors, give reason to believe that the situation will improve in later months. Thus, the MEI Board, the Organizing Committee and Program Committee of the Music Encoding Conference 2021 in Alicante have decided to postpone the event by two months. The conference is now scheduled to take place from **Monday 19 to Thursday 22 July 2021** and is additionally being prepared to be held in **hybrid mode** to allow either physical or virtual participation.
+
+For latest infos and schedules, please consult the <a href="http://music-encoding.org/conference/2021/call">Call for Proposals</a>


### PR DESCRIPTION
While announcing the postponed MEC on the conference page itself, we missed to add a news post on the front page (thanks @kepper for pointing out).

This PR adds the news post.