### PR TITLE
fix(tools): add side menu entry for meico

### DIFF
--- a/_layouts/tools.html
+++ b/_layouts/tools.html
@@ -22,6 +22,7 @@ layout: default
         <li class="nav-item"><a href="#mermeid">MerMEId</a></li>
         <li class="nav-item"><a href="#sibmei">SibMEI</a></li>
         <li class="nav-item"><a href="#libmei">LibMEI</a></li>
+        <li class="nav-item"><a href="#meico-mei-converter">meico: MEI Converter</a></li>
         <li class="nav-item"><a href="#mei-to-music21-converter">MEI to Music21 Converter</a></li>
         <li class="nav-item"><a href="#meiler">MEILER</a></li>
         <!-- <li class="nav-item"><a href="#meise">MEISE</a></li> -->


### PR DESCRIPTION
Short one line postscript PR for #203

Missed to add the side menu entry for meico on the tools site (we should have this automated in the future, cf. #130 )

