### PR TITLE
Update bibliography

### DIFF
--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -54,6 +54,20 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
 }
 
 
+@book{Bue_2021,
+ abstract = {Digital musicology is a diverse area of research. For many, the under-standing of “music” within Digital Humanities concerns sound, recordings, or music notation software. The articles in this collection, however, discuss different aspects of digital musicology: primarily how pre-existing notated music can be represented digitally. The articles deal with subjects such as digital reconstruction, editing, encoding, databases, digital preservation and computational analysis of notated music.},
+ title = {{Notated Music in the Digital Sphere. Possibilities and Limitations}},
+ editor = {Bue, Margrethe Støkken and Rockenberger, Annika},
+ publisher = {National Library of Norway},
+ location = {Oslo},
+ year = {2021},
+ url_Volume = {https://issuu.com/nasjonalbiblioteket/docs/nota_bene_15_layout_issuu},
+ urldate = {2021-03-02},
+ series = {Nota bene -- Studies from the National Library of Norway},
+ volume = {15}
+}
+
+
 @inproceedings{Burlet_2012,
  abstract = {This paper introduces Neon.js, a browser-based music notation editor written in JavaScript. The editor can be used to manipulate digitally encoded musical scores in square-note notation. This type of notation presents certain challenges to a music notation editor, since many neumes (groups of pitches) are ligatures–continuous graphical symbols that represent multiple notes. Neon.js will serve as a component within an online optical music recognition framework. The primary purpose of the editor is to provide a readily accessible interface to easily correct errors made in the process of optical music recognition. In this context, we envision an environment that promotes crowdsourcing to further the creation of editable and searchable online symbolic music collections and for generating and editing ground-truth data to train optical music recognition algorithms.},
  author = {Burlet, Gregory and Porter, Alastair and Hankinson, Andrew and Fujinaga, Ichiro},
@@ -516,6 +530,22 @@ In this context, this Ph.D. dissertation aims to develop a theoretical model for
 }
 
 
+@incollection{Moe_2021,
+ abstract = {The article is concerned with discussing the role of the encoder of musical notation and with exploring how to make choices when encoding. A central point is that decision-making is to a large extent dependent on the purpose of the encoding. Consequently, the editor needs to take into consideration who is going to use the encoding and how. Taking its point of departure from an ongoing project on sixteenth-century monophonic songs, the article discusses the relationship between the visual appearance of notation and the meaning of it. Furthermore, the article explores how an editor is able to address problems during the interpretation and presentation of the source by employing Music Encoding Initiative (MEI).},
+ author = {Moe, Bjarke},
+ title = {{The Editor's Choice. From Sixteenth-Century Sources to Digital Editions Using MEI}},
+ editor = {Bue, Margrethe Støkken and Rockenberger, Annika},
+ booktitle = {{Notated Music in the Digital Sphere. Possibilities and Limitations}},
+ address = {Oslo},
+ publisher = {National Library of Norway},
+ year = {2021},
+ pages = {57–75},
+ series = {Nota bene -- Studies from the National Library of Norway},
+ volume = {15},
+ url = {https://issuu.com/nasjonalbiblioteket/docs/nota_bene_15_layout_issuu/57},
+}
+
+
 @misc{Morent_2006,
  abstract = {},
  author = {Morent, Stefan and Schr{\"a}der, Gregor},
@@ -903,6 +933,22 @@ journal = {Die Musikforschung}
 }
 
 
+@incollection{TeichGeertinger_2021,
+ abstract = {There are profound differences between the notation of text and music in terms of their purpose, use of symbols and how they translate into a machine-readable form. This paper identifies the difficulties of encoding music notation as compared to text and how these difficulties may be handled. Despite the challenges, encoding formats for notated music which are as sophisticated as comparable textual formats are now available, such as the XML schema defined by the Music Encoding Initiative (MEI). But are there any limits to what is possible to encode? The author argues that today the primary limiting factor is not the available encoding systems but rather the ambiguity and complexity of music notation itself.},
+ author = {{Teich Geertinger}, Axel},
+ title = {{Digital Encoding of Music Notation with MEI}},
+ editor = {Bue, Margrethe Støkken and Rockenberger, Annika},
+ booktitle = {{Notated Music in the Digital Sphere. Possibilities and Limitations}},
+ address = {Oslo},
+ publisher = {National Library of Norway},
+ year = {2021},
+ pages = {35–56},
+ series = {Nota bene -- Studies from the National Library of Norway},
+ volume = {15},
+ url = {https://issuu.com/nasjonalbiblioteket/docs/nota_bene_15_layout_issuu/35},
+}
+
+
 @misc{TEIMusicSIG_2012,
  abstract = {As part of a project funded by the TEI, the group focussed on using TEI's One Document Does it all (ODD) vocabulary to connect the TEI to music encoding formats. Specifically, first efforts concentrated on the Music Encoding Initiative (MEI) format. Therefore, these guidelines describe a TEI-with-MEI customisation that uses the TEI element <notatedMusic> to embed encode music notation.
 The examples in these guidelines present typical occurrences of music within written text. They are taken from a handful of documents that we believe demonstrate the need for the inclusion of encoded music notation within TEI-encoded texts. See the bibliography for more information.
@@ -1048,26 +1094,4 @@ The API was evaluated by: 1) creating an implementation of the API for documents
  booktitle = {Proceedings of the Second International Conference on Technologies for Music Notation and Representation, TENOR 2016, Cambridge, UK, May 27–29, 2016},
  year = {2016},
  address = {Cambridge, UK}
-}
-
-@collection{Bue_Rockenberger_2021,
-title = {{Notated Music in the Digital Sphere}},
-subtitle = {{Possibilities and Limitations}},
-editor = {Margrethe Støkken Bue and Annika Rockenberger},
-publisher = {National Library of Norway},
-abstract = {Digital musicology is a diverse area of research. For many, the under-standing  of  “music”  within  Digital  Humanities  concerns  sound,  recordings, or music notation software. The articles in this collection, however, discuss different aspects of digital musicology: primarily how pre-existing notated music can be represented digitally. The articles deal  with  subjects  such  as  digital  reconstruction,  editing,  encoding,  databases, digital preservation and computational analysis of notated music.},
-location = {Oslo},
-year = {2021},
-url = {https://issuu.com/nasjonalbiblioteket/docs/nota_bene_15_layout_issuu},
-urldate = {2021-03-02},
-series = {Nota bene -- Studies from the National Library of Norway},
-number = {15}
-}
-
-@incollection{Geertinger_2021,
-author = {Axel Teich  Geertinger},
-title = {{Digital Encoding of Music Notation with MEI}},
-pages = {35--56},
-abstract = {There are profound differences between the notation of text and music in terms of their purpose, use of symbols and how they translate into a machine-readable form. This paper identifies the difficulties of encod-ing music notation as compared to text and how these difficulties may be  handled.  Despite  the  challenges,  encoding  formats  for  notated  music  which  are  as  sophisticated  as  comparable  textual  formats  are  now available, such as the XML schema defined by the Music Encod-ing  Initiative  (MEI).  But  are  there  any  limits  to  what  is  possible  to  encode? The author argues that today the primary limiting factor is not the available encoding systems but rather the ambiguity and com-plexity of music notation itself.},
-crossref ={Bue_Rockenberger_2021}
 }

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -169,6 +169,17 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  journal = {Musiktheorie. Zeitschrift für Musikwissenschaft}
 }
 
+
+@proceedings{DeLuca_2020,
+ abstract = {Conference proceedings of the Music Encoding Conference 2020 with Foreword by Richard Freedman and Anna J. Kijas},
+ year = {2020},
+ title = {{Music Encoding Conference Proceedings 2020}},
+ publisher = {{Humanities Commons}},
+ editor = {{De Luca}, Elsa and Flanders, Julia},
+ doi = {10.17613/mvxw-x477}
+}
+
+
 @mastersthesis{Destandau_2016,
  abstract = {A l’heure du numérique, les pratiques musicales se transforment et les objets qui les véhiculent aussi. Dans ce contexte, ce mémoire étudie la façon dont la Music Encoding Initiative, un format d’encodage pour la musique notée, interagit avec les usages. Il montre que la définition du modèle de description suppose une bonne connaissance du domaine qu’il représente, et un positionnement clair ; que les évolutions du modèle pour s’adapter à de nouvelles pratiques questionnent sa cohérence ; mais que cette flexibilité est pourtant indispensable car c’est elle qui rend le modèle vivant et permet de fédérer autour de lui une communauté, qui invente à son tour de nouvelles applications},
  author = {Destandau, Marie},
@@ -207,6 +218,16 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  year = {2019},
  doi = {10.1007/s00799-017-0229-3},
  url = {https://link.springer.com/content/pdf/10.1007%2Fs00799-017-0229-3.pdf}
+}
+
+
+@proceedings{DiBacco_2019,
+ abstract = {Conference proceedings of the Music Encoding Conferences 2015, 2016 and 2017 with Introduction by Giuliano Di Bacco},
+ year = {2019},
+ title = {{Music Encoding Conference Proceedings 2015, 2016 and 2017}},
+ publisher = {{Bavarian State Library (BSB)}},
+ editor = {{Di Bacco}, Giuliano and Kepper, Johannes and Roland, Perry},
+ doi = {10.15463/music-1}
 }
 
 
@@ -789,15 +810,15 @@ url = {https://link.springer.com/content/pdf/10.1007%2Fs00799-018-0262-x.pdf}
 }
 
 
-@proceedings{Roland_2015,
- abstract = {},
- year = {2015},
- title = {Music Encoding Conference Proceedings, 2013 and 2014},
+@proceedings{Roland_2016,
+ abstract = {Conference proceedings of the Music Encoding Conferences 2013 and 2014 with Foreword by Perry D. Roland and Johannes Kepper},
+ year = {2016},
+ title = {{Music Encoding Conference Proceedings 2013 and 2014}},
  url_URN = {http://nbn-resolving.de/urn:nbn:de:bvb:12-babs2-0000007812},
- publisher = {{Music Enconding Initiative}},
- editor = {Roland, Perry and Kepper, Johannes},
- key = {Roland, Perry and Kepper, Johannes}
+ publisher = {{Bavarian State Library (BSB)}},
+ editor = {Roland, Perry and Kepper, Johannes}
 }
+
 
 @inproceedings{Sapov_2020,
  abstract = {Algorithmic automation of the complex music notation rules in MEI-XML through the example of the accidentals: The article demonstrates how music notation rules can be formalized into a computer algorithm. In particular, it handles the rule, whether the accidentals should be rendered or not when they repeat on the notes of the same pitch in the same measure. The decision process is described step-by-step while referring to the music notation rules. The algorithm was implemented in the XSLT-language for the needs of the Digital Interactive Mozart Edition and can be applied to MEI data. The tool can be downloaded from https://github.com/ismdme/DIME-tools.},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -464,6 +464,16 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
 }
 
 
+@misc{Leon_2017,
+ abstract = {Since the 1950’s, computers have been utilized heavily to further the study of music. Now, music is conceived, recorded, produced, stored, and consumed almost entirely with the assistance of computers. Though music and computers are deeply intertwined in the modern age, there is still a disconnect between music notation and computer representation. As an avid lover of both music and computer science, I became intrigued with this void in computer music. What is the proper way to store and symbolize musical scores? Is there a way to encode scores that do not follow standardized rules of notation? Inspired by both the old and new methods of computer music composition and technology, this project seeks to overcome the boundaries between music notation and digital encoding. […] Using a combination of Python, MEI, and JavaScript, I detail below a method for the encoding and representation of graphic musical notation as well as the creation of an interactive score utilizing this encoding.},
+ author = {Leon, Matthew},
+ year = {2017},
+ title = {Encoding Non-Standard Forms of Music Notation Using MEI (May 2016)},
+ url = {http://www4.iath.virginia.edu/mei/ML/encoding.pdf},
+ note = {Music & Computer Science, University of Virginia, Class of 2017. Project for Student Digital Humanities Fellowship.}
+}
+
+
 @article{Lewis_2015,
  abstract = {Transforming Musicology is a three-year project undertaking musicological research exploring state-of-the-art computational methods in the areas of early modern vocal and instrumental music (mostly for lute), Wagner’s use of leitmotifs, and music as represented in the social media. An essential component of the work involves devising a semantic infrastructure which allows research data, results and methods to be published in a form that enables others to incorporate the research into their own discourse. This includes ways of capturing the processes of musicology in the form of ‘workflows’; in principle, these allow the processes to be repeated systematically using improved data, or on newly discovered sources as they emerge. A large part of the effort of Transforming Musicology (as with any digital research) is concerned with data preparation, which in the early music case described here means dealing with the outputs of optical music recognition software, which inevitably contain errors. This report describes in outline the process of correction and some of the web-based software which has been designed to make this as easy as possible for the musicologist.},
  author = {Lewis, Richard J. and Crawford, Tim and Lewis, David},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -359,7 +359,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  journal = {Forum Musikbibliothek: Beitrage und Informationen aus der Musikbibliothekarischen Praxis}
 }
 
-@inproceedings{kallionpaa_et_al_2017,
+@inproceedings{Kallionpaa_et_al_2017,
  booktitle = {NIME 2017: New Interfaces for Musical Expression, Copenhagen, 15--18 May 2017: Proceedings},
  editor = {Erkut, Cumhur},
  month = {May},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -114,6 +114,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  note = {Revised version of the 2003 paper in Computer Music Journal}
 }
 
+
 @inproceedings{Cox_2020,
  abstract = {In its second module, "Beethovens Werkstatt" deals with five of Beethoven's compositions which exist both in their original versions and as authentic arrangements (Piano Sonata op. 14/1 arranged for string quartet, Septett op. 20 and Trio op. 38, Opferlied op. 121b and Bundeslied op. 122 as piano reductions, Gro{\ss}e Fuge op. 133 as arrangement for piano for four hands op. 134). To demonstrate Beethoven's arrangement practices, the original version of each work is synoptically linked with its arrangement in a digital edition called "VideApp Arr". Through digital tools for comparison the relationships between the two versions can be investigated from different perspectives. It becomes visible how the versions are related to each other both by "invariance" (text elements with the same structure), by "variance" (text elements with a similar structure) and, in special cases, also by "difference" (text elements without corresponding parameters). Each view within the "VideApp Arr" is generated from the underlying MEI data.},
  author = {Cox, Susanne and S{\"a}nger, Richard},
@@ -128,6 +129,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  doi = {10.25366/2020.99}
 }
 
+
 @article{Crawford_2016,
  abstract = {It will not have escaped the notice of many readers of this Journal that a number of ambitious projects in historical musicology with a major IT component have received generous grant funding in recent years. Underpinning each of these projects is the music-encoding standard known as the Music Encoding Initiative (MEI). […] Clearly MEI is here to stay. In this report we aim to give a sketch of its main features, which potentially enable new modes ofmusic research, and a hint of its impact on the discipline ofmusicology.},
  author = {Crawford, Tim and Lewis, Richard},
@@ -140,6 +142,7 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
  journal = {Journal of the American Musicological Society},
  doi = {10.1525/jams.2016.69.1.273}
 }
+
 
 @article{DeLuca_2019,
  abstract = {This paper describes the challenges involved in designing a computer encoding system for early plainchant notation (both with and without staff lines) and, in particular, Old Hispanic neume notation. We have been working on a new version of the Music Encoding Initiative (MEI) schema for neume notations since 2012. Our goal and that of MEI is to digitally represent as accurately as possible the notation in musical sources, especially its semantics wherever possible, so that the encoded files can be used for various musical research purposes, such as creating critical editions and data mining. Of the early plainchant notations, Old Hispanic neume notation is the least understood. We will present some of our solutions to resolve the specific issues surrounding Old Hispanic notation while maintaining compatibility with the encoding of other styles of plainchant notation.},
@@ -621,6 +624,7 @@ In this context, this Ph.D. dissertation aims to develop a theoretical model for
  doi = {10.1145/2970044.2970046}
 }
 
+
 @article{Rizo_2019,
 abstract = {We propose a standard representation for hierarchical musical analyses as an extension to the Music Encoding Initiative (MEI) representation for music. Analyses of music need to be represented in digital form for the same reasons as music: preservation, sharing of data, data linking, and digital processing. Systems exist for representing sequential information, but many music analyses are hierarchical, whether represented explicitly in trees or graphs or not. Features of MEI allow the representation of an analysis to be directly associated with the elements of the music analyzed. MEI’s basis in TEI (Text Encoding Initiative), allows us to design a scheme which reuses some of the elements of TEI for the representation of trees and graphs. In order to capture both the information specific to a type of music analysis and the underlying form of an analysis as a tree or graph, we propose related “semantic” encodings, which capture the detailed information, and generic “non-semantic” encodings which expose the tree or graph structure. We illustrate this with examples of representations of a range of different kinds of analysis.},
 author = {Rizo, David and Marsden, Alan},
@@ -780,6 +784,7 @@ url = {https://link.springer.com/content/pdf/10.1007%2Fs00799-018-0262-x.pdf}
  doi = {10.25366/2020.98}
 }
 
+
 @inproceedings{Sapp_2015,
  abstract = {This paper discusses the SCORE data format, a graphically oriented music representation developed in the early 1970's, and how such a representation can be converted into sequential descriptions of music notation. The graphical representation system for the SCORE editor is presented along with case studies for parsing and converting the data into other symbolic music formats such as Dox, Humdrum, MusicXML, MuseData, MEI, and MIDI using scorelib, an open-source code library for parsing SCORE data. Knowledge and understanding of the SCORE format is also useful for OMR (Optical Music Recognition) projects, as it can be used as an intermediate layer between raw image scans and higher-level digital music representation systems.},
  author = {Sapp, Craig},
@@ -817,6 +822,7 @@ volume = {71},
 number = {4},
 journal = {Die Musikforschung}
 }
+
 
 @inproceedings{Seipelt_2020,
  abstract = {The poster shows the results obtained in the project "Digital Music Analysis with the Techniques of the Music Encoding Initiative (MEI) using Anton Bruckner's compositional studies as an example" (2017 to 2019). On the one hand, the project had the goal of presenting a digital edition of Anton Bruckner's study book, which he produced during his lessons with Otto Kitzler from 1861 to 1863. An edition of the music in the textbook encoded with MEI and displayed using Verovio and the facsimile can be displayed simultaneously. On the other hand, an automated harmonic analysis of this music was to be designed. For this purpose, keys are recognized using the Krumhansl-Schmuckler algorithm that is based on a resource of pitch classes which are compared with reference values and thus their similarity is calculated. Based on this, chord recognitions are carried out, which are then linked to the keys in the last step and converted to a roman numeral analysis.},

--- a/resources/mei_bibliography.bib
+++ b/resources/mei_bibliography.bib
@@ -3,18 +3,18 @@
 % modified 2019-10-27
 
 @incollection{behrendt_bain_helsen_2017,
-  publisher = {Books on Demand},
-  volume = {11},
-  author = {Inga Behrendt and Jennifer Bain and Kate Helsen},
-  address = {Norderstedt},
-  month = {July},
-  editor = {Hannah Busch and Franz Fischer and Patrick Sahle},
-  pages = {275--291},
-  booktitle = {Kodikologie und Pal{\"a}ographie im Digitalen Zeitalter 4 -- Codicology and Palaeography in the Digital Age 4},
-  title = {MEI Kodierung der fr{\"u}hesten Notation in linienlosen Neumen},
-  year = {2017},
-  url = {https://kups.ub.uni-koeln.de/7789/},
-  abstract = {Das Optical Neume Recognition Project (ONRP) hat die digitale Kodierung von musikalischen Notationszeichen aus dem Jahr um 1000 zum Ziel – ein ambitioniertes Vorhaben, das die Projektmitglieder veranlasste, verschiedenste methodische Ans{\"a}tze zu evaluieren. Die Optical Music Recognition-Software soll eine linienlose Notation aus einem der {\"a}ltesten erhaltenen Quellen mit Notationszeichen, dem Antiphonar Hartker aus der Benediktinerabtei St. Gallen (Schweiz), welches heute in zwei B{\"a}nden in der Stiftsbibliothek in St. Gallen aufbewahrt wird, erfassen. Aufgrund der handgeschriebenen, linienlosen Notation stellt dieser Gregorianische Gesang den Forscher vor viele Herausforderungen. Das Werk umfasst {\"u}ber 300 verschiedene Neumenzeichen und ihre Notation, die mit Hilfe der Music Encoding Initiative (MEI) erfasst und beschrieben werden sollen. Der folgende Artikel beschreibt den Prozess der Adaptierung, um die MEI auf die Notation von Neumen ohne Notenlinien anzuwenden. Beschrieben werden Eigenschaften der Neumennotation, um zu verdeutlichen, wo die Herausforderungen dieser Arbeit liegen sowie die Funktionsweise des Classifiers, einer Art digitalen Neumenw{\"o}rterbuchs.}
+ publisher = {Books on Demand},
+ volume = {11},
+ author = {Inga Behrendt and Jennifer Bain and Kate Helsen},
+ address = {Norderstedt},
+ month = {July},
+ editor = {Hannah Busch and Franz Fischer and Patrick Sahle},
+ pages = {275--291},
+ booktitle = {Kodikologie und Pal{\"a}ographie im Digitalen Zeitalter 4 -- Codicology and Palaeography in the Digital Age 4},
+ title = {MEI Kodierung der fr{\"u}hesten Notation in linienlosen Neumen},
+ year = {2017},
+ url = {https://kups.ub.uni-koeln.de/7789/},
+ abstract = {Das Optical Neume Recognition Project (ONRP) hat die digitale Kodierung von musikalischen Notationszeichen aus dem Jahr um 1000 zum Ziel – ein ambitioniertes Vorhaben, das die Projektmitglieder veranlasste, verschiedenste methodische Ans{\"a}tze zu evaluieren. Die Optical Music Recognition-Software soll eine linienlose Notation aus einem der {\"a}ltesten erhaltenen Quellen mit Notationszeichen, dem Antiphonar Hartker aus der Benediktinerabtei St. Gallen (Schweiz), welches heute in zwei B{\"a}nden in der Stiftsbibliothek in St. Gallen aufbewahrt wird, erfassen. Aufgrund der handgeschriebenen, linienlosen Notation stellt dieser Gregorianische Gesang den Forscher vor viele Herausforderungen. Das Werk umfasst {\"u}ber 300 verschiedene Neumenzeichen und ihre Notation, die mit Hilfe der Music Encoding Initiative (MEI) erfasst und beschrieben werden sollen. Der folgende Artikel beschreibt den Prozess der Adaptierung, um die MEI auf die Notation von Neumen ohne Notenlinien anzuwenden. Beschrieben werden Eigenschaften der Neumennotation, um zu verdeutlichen, wo die Herausforderungen dieser Arbeit liegen sowie die Funktionsweise des Classifiers, einer Art digitalen Neumenw{\"o}rterbuchs.}
 }
 
 
@@ -322,15 +322,15 @@ These techniques are demonstrated using a sample of orchestral scores annotated 
 }
 
 @inproceedings{kallionpaa_et_al_2017,
-  booktitle = {NIME 2017: New Interfaces for Musical Expression, Copenhagen, 15--18 May 2017: Proceedings},
-  editor = {Erkut, Cumhur},
-  month = {May},
-  title = {Composing and Realising a Game-Like Performance for Disklavier and Electronics},
-  author = {Maria Kallionp{\"a}{\"a} and Chris Greenhalgh and Adrian Hazzard and David M. Weigl and Kevin R. Page and Steve Benford},
-  year = {2017},
-  pages = {464--469},
-  url = {http://eprints.nottingham.ac.uk/44529/},
-  abstract = {"Climb!" is a musical composition that combines the ideas of a classical virtuoso piece and a computer game. We present a case study of the composition process and realization of "Climb!", written for Disklavier and a digital interactive engine, which was co-developed together with the musical score. Specifically, the engine combines a system for recognising and responding to musical trigger phrases along with a dynamic digital score renderer. This tool chain allows for the composer's original scoring to include notational elements such as trigger phrases to be automatically extracted to auto-configure the engine for live performance. We reflect holistically on the development process to date and highlight the emerging challenges and opportunities. For example, this includes the potential for further developing the workflow around the scoring process and the ways in which support for musical triggers has shaped the compositional approach.}
+ booktitle = {NIME 2017: New Interfaces for Musical Expression, Copenhagen, 15--18 May 2017: Proceedings},
+ editor = {Erkut, Cumhur},
+ month = {May},
+ title = {Composing and Realising a Game-Like Performance for Disklavier and Electronics},
+ author = {Maria Kallionp{\"a}{\"a} and Chris Greenhalgh and Adrian Hazzard and David M. Weigl and Kevin R. Page and Steve Benford},
+ year = {2017},
+ pages = {464--469},
+ url = {http://eprints.nottingham.ac.uk/44529/},
+ abstract = {"Climb!" is a musical composition that combines the ideas of a classical virtuoso piece and a computer game. We present a case study of the composition process and realization of "Climb!", written for Disklavier and a digital interactive engine, which was co-developed together with the musical score. Specifically, the engine combines a system for recognising and responding to musical trigger phrases along with a dynamic digital score renderer. This tool chain allows for the composer's original scoring to include notational elements such as trigger phrases to be automatically extracted to auto-configure the engine for live performance. We reflect holistically on the development process to date and highlight the emerging challenges and opportunities. For example, this includes the potential for further developing the workflow around the scoring process and the ways in which support for musical triggers has shaped the compositional approach.}
 }
 
 
@@ -992,28 +992,28 @@ The API was evaluated by: 1) creating an implementation of the API for documents
 }
 
 @inproceedings{weigl_page_2017a,
-  author = {Weigl, David M. and Page, Kevin R.},
-  editor = {Blomqvist, Eva and Hose, Katja and Paulheim, Heiko and Lawrynowicz, Agnieszka and Ciravegna, Fabio and Hartig, Olaf},
-  title = {Dynamic Semantic Music Notation},
-  booktitle = {The Semantic Web: ESWC 2017 Satellite Events},
-  year = {2017},
-  publisher = {Springer International Publishing},
-  address = {Cham},
-  pages = {31--34},
-  abstract = {The Music Encoding Initiative (MEI) XML schema expresses musical structure addressing score elements at musically meaningful levels of granularity (e.g., individual systems, measures, or notes). While this provides a comprehensive representation of music content, only concepts and relationships provided by the MEI schema can be encoded. Here, we present our Music Encoding and Linked Data (MELD) framework which applies RDF Web Annotations to targetted portions of the MEI structure. Concepts and relationships from the Semantic Web can be included alongside MEI in an expanded musical knowledge graph. We have implemented a music performance scenario which collects, distributes, and displays semantic annotations, enhancing a digital musical score used by performers in a live music jam session.},
-  isbn = {978-3-319-70407-4},
-  url = {https://link.springer.com/content/pdf/10.1007%2F978-3-319-70407-4_7.pdf},
-  doi = {10.1007/978-3-319-70407-4_7}
+ author = {Weigl, David M. and Page, Kevin R.},
+ editor = {Blomqvist, Eva and Hose, Katja and Paulheim, Heiko and Lawrynowicz, Agnieszka and Ciravegna, Fabio and Hartig, Olaf},
+ title = {Dynamic Semantic Music Notation},
+ booktitle = {The Semantic Web: ESWC 2017 Satellite Events},
+ year = {2017},
+ publisher = {Springer International Publishing},
+ address = {Cham},
+ pages = {31--34},
+ abstract = {The Music Encoding Initiative (MEI) XML schema expresses musical structure addressing score elements at musically meaningful levels of granularity (e.g., individual systems, measures, or notes). While this provides a comprehensive representation of music content, only concepts and relationships provided by the MEI schema can be encoded. Here, we present our Music Encoding and Linked Data (MELD) framework which applies RDF Web Annotations to targetted portions of the MEI structure. Concepts and relationships from the Semantic Web can be included alongside MEI in an expanded musical knowledge graph. We have implemented a music performance scenario which collects, distributes, and displays semantic annotations, enhancing a digital musical score used by performers in a live music jam session.},
+ isbn = {978-3-319-70407-4},
+ url = {https://link.springer.com/content/pdf/10.1007%2F978-3-319-70407-4_7.pdf},
+ doi = {10.1007/978-3-319-70407-4_7}
 }
 
 @inproceedings{weigl_page_2017b,
-  abstract = {Music  notation  expresses  performance  instructions  in  a way commonly understood by musicians, but printed paper parts are limited to encodings of static, a priori knowledge. In  this  paper  we  present  a  platform  for  multi-way  communication  between  collaborating  musicians  through  the dynamic modification of digital parts:  the Music Encoding  and  Linked Data  (MELD)  framework  for distributed real-time annotation of digital music scores.  MELD users and software agents create semantic annotations of music concepts and relationships, which are associated with musical structure specified by the Music Encoding Initiative schema (MEI). Annotations are expressed in RDF, allowing alternative music vocabularies (e.g., popular vs.  classical music structures) to be applied.  The same underlying framework retrieves, distributes, and processes information that addresses semantically distinguishable music elements.  Further knowledge is incorporated from external sources through the use of Linked Data.  The RDF is also used to match annotation types and contexts to rendering actions which display the annotations upon the digital score.  Here, we present a MELD implementation and deployment which augments the digital music scores used by musicians in a group performance, collaboratively changing the sequence within and between pieces in a set list.},
-  year = {2017},
-  url = {https://ismir2017.smcnus.org/wp-content/uploads/2017/10/190_Paper.pdf},
-  title = {A Framework for Distributed Semantic Annotation of Musical Score: "Take it to the Bridge!"},
-  author = {Weigl, David M. and Page, Kevin},
-  booktitle = {Proceedings of the 18th International Society for Music Information Retrieval Conference, ISMIR 2017, Suzhou, China, October 23--27, 2017},
-  isbn = {978-981-11-5179-8}
+ abstract = {Music notation expresses performance instructions in a way commonly understood by musicians, but printed paper parts are limited to encodings of static, a priori knowledge. In this paper we present a platform for multi-way communication between collaborating musicians through the dynamic modification of digital parts: the Music Encoding and Linked Data (MELD) framework for distributed real-time annotation of digital music scores. MELD users and software agents create semantic annotations of music concepts and relationships, which are associated with musical structure specified by the Music Encoding Initiative schema (MEI). Annotations are expressed in RDF, allowing alternative music vocabularies (e.g., popular vs. classical music structures) to be applied. The same underlying framework retrieves, distributes, and processes information that addresses semantically distinguishable music elements. Further knowledge is incorporated from external sources through the use of Linked Data. The RDF is also used to match annotation types and contexts to rendering actions which display the annotations upon the digital score. Here, we present a MELD implementation and deployment which augments the digital music scores used by musicians in a group performance, collaboratively changing the sequence within and between pieces in a set list.},
+ year = {2017},
+ url = {https://ismir2017.smcnus.org/wp-content/uploads/2017/10/190_Paper.pdf},
+ title = {A Framework for Distributed Semantic Annotation of Musical Score: "Take it to the Bridge!"},
+ author = {Weigl, David M. and Page, Kevin},
+ booktitle = {Proceedings of the 18th International Society for Music Information Retrieval Conference, ISMIR 2017, Suzhou, China, October 23--27, 2017},
+ isbn = {978-981-11-5179-8}
 }
 
 


### PR DESCRIPTION
This PR fixes some Bibbase-related issues that occured with #211. The changes correctly introduced by @doerners in #211 did not show up on the website, because Bibbase is sometimes a bit quirky esp. in relation to naming of types, tags; or even to (Bib)TeX-specific string patterns like `--` for dash. Also, `crossref` or `subtitle` aren't handled very well by Bibbase.

The entries are fixed now and sorted by alphabetical order. Furthermore, it adds two more papers (Moe 2021 and Leon 2017) as well as entries for the MEC proceedings.

Finally, the PR fixes some indentations, line breaks and small typos in the bib file.