### PR TITLE
Fix invalid or obsolete HTML (post scriptum)

### DIFF
--- a/_includes/menu-accordion.html
+++ b/_includes/menu-accordion.html
@@ -24,9 +24,9 @@
             <div class="accordion-body">
               <ul class="menu menu-nav">
                 {% for item in entry.submenu %}
-                  {% if forloop.first %} <ul class="menu"> {% endif %}
+                  {% if forloop.first %} <li><ul class="menu"> {% endif %}
                   <li class="menu-item"><a href="{{entry.url}}{{item.url}}">{{item.label}}</a></li>
-                  {% if forloop.last %} </ul> {% endif %}
+                  {% if forloop.last %} </ul></li> {% endif %}
                 {% endfor %}
               </ul>
             </div>


### PR DESCRIPTION
Sorry, missed that one in #215, since it is embedded in a mixture of html and jekyll liquids here: https://github.com/music-encoding/music-encoding.github.io/blob/master/_includes/menu-accordion.html#L26-L30

UL cannot be directly nested into another UL, but only as a child of LI (cf. https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#nesting_lists).

@bwbohl Could you please double-check for any potential CSS issues?

