### PR TITLE
fix(conference): reintegrate MEC2020 Code of Conduct

### DIFF
--- a/_conferences/2020/code-of-conduct.html
+++ b/_conferences/2020/code-of-conduct.html
@@ -4,7 +4,6 @@ title: "Code of Conduct"
 permalink: "/conference/2020/code-of-conduct/"
 tag: MEC2020
 id: code-of-conduct
-published: false
 ---
 
 <img src="/images/conference/2020/MEC4.jpg" class="img-responsive" alt="Music Encoding Conference, Tufts University, 26-29 May 2020"/>


### PR DESCRIPTION
Just a very small PR to reintegrate the Code of Conduct in the MEC2020 pages. It was somehow removed, but is referenced from the MEC2020 index page.