### PR TITLE
MEC2021: update affiliations and PC team

### DIFF
--- a/_conferences/2021/call.html
+++ b/_conferences/2021/call.html
@@ -132,6 +132,7 @@ id: call
       <li>Giuliano Di Bacco, Indiana University</li>
       <li>Sophia Dörner, Humboldt University of Berlin</li>
       <li>Julia Flanders, Northeastern University</li>
+      <li>Jan Hajič, jr., Masaryk Institute and Archives of the CAS</li>
       <li>Kristin Herold, Paderborn University</li>
       <li>Stefan Münnich (Committee Chair), University of Basel</li>
       <li>Craig Sapp, Stanford University, CCARH, Packard Humanities Institute</li>

--- a/_conferences/2021/people.html
+++ b/_conferences/2021/people.html
@@ -19,11 +19,12 @@ program:
     - "Giuliano Di Bacco, Indiana University, USA"
     - "Sophia Dörner, Humboldt University of Berlin, Germany"
     - "Julia Flanders, Northeastern University, USA"
+    - "Jan Hajič, jr., Masaryk Institute and Archives of the CAS, Czech Republic"
     - "Kristin Herold, Paderborn University, Germany"
     - "Craig Sapp, Stanford University, CCARH, Packard Humanities Institute, USA"
     - "Martha E. Thomae, McGill University, Canada"
 keynotes:
     - "Pip Willcox, Head of Research, The National Archives, UK"
-    - "Álvaro Torrente, Didone Project, Universidad Complutense de Madrid, Spain"
+    - "Álvaro Torrente, Professor of Music History, Universidad Complutense de Madrid, and Director, Instituto Complutense de Ciencias Musicales, Spain"
 
 ---


### PR DESCRIPTION
As an addendum for #221, this small PR updates affiliations and entries for keynote speakers and members of the PC team.