### PR TITLE
Add latest events to news

### DIFF
--- a/_posts/2021-06-15-mec2021-programme.md
+++ b/_posts/2021-06-15-mec2021-programme.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Conference program uploaded for MEC 2021"
+date:   2021-06-15 15:00
+categories: update
+---
+
+The conference program for the Music Encoding Conference 2021, 19-22 July 2021 at the University of Alicante / Online has been uploaded to <a href="https://music-encoding.org/conference/2021/program/">https://music-encoding.org/conference/2021/program/</a>.
+
+Please also note that early bird registration has been extended to June 21st (<a href="https://music-encoding.org/conference/2021/register/">https://music-encoding.org/conference/2021/register/</a>).
+
+For current travel procedures visit <a href="https://music-encoding.org/conference/2021/travel/">https://music-encoding.org/conference/2021/travel/</a>. For information about COVID-19 protection measures in Alicante, please check <a href="https://music-encoding.org/conference/2021/covid-19/">https://music-encoding.org/conference/2021/covid-19/</a>.
+
+Looking forward to seeing you either online or physically.

--- a/_posts/2021-06-15-teaching-music-history-session.md
+++ b/_posts/2021-06-15-teaching-music-history-session.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title:  "Event: Music encoding related session at Teaching Music History Conference 2021"
+date:   2021-06-15 14:00
+categories: update
+---
+
+The 2021 Teaching Music History Conference, organized by the Pedagogy Study Group of the American Musicological Society, will be held virtually from June 14-18 and June 21-25. All presentations are scheduled for 4:00-5:30 PM (EST). You may view the program at https://tinyurl.com/tmhc2021. There is a session of interest to the MEI community on Tuesday, June 15.
+
+The conference is free to attend! Please register at https://tinyurl.com/TMHC2021reg to stay informed and receive the Zoom link.
+
+**Teaching Music History Conference 2021**
+
+*Session: Using New Technologies to Enhance Teaching*
+
+Tuesday, June 15 (4:00 – 5:30 PM) 
+
+Session Chair: Timothy Cochran (Eastern Connecticut State University)
+
+
+**4:00 PM (EDT) – The Song’s Opening – Mark Gotham (Universität des Saarlandes & fourscoreandmore.org)**
+
+One defining development of the digital age is increased accessibility – more content is available to more people than ever. This session presents new digital resources for increased diversity and accessibility in music teaching, starting with the OpenScore Lieder Corpus, a collection of over 1,000 songs encoded by an academic-community collaboration and released under a licence that enables all use-cases including playback, transposition, and ‘music-minus-one’ directly in the webpage. This collection is powerfully inclusive. First, the additional functionality (beyond print or PDF) makes it easier for anyone who is not an expert score reader to engage with these songs. Re-doubling the significance of that accessibility is the greater diversity of repertoire presented, including many songs that have never been published or recorded. This aids the historical discussion of nineteenth century musical practice, framing the scope in terms of a genre particularly open to all; less dependent on centralised, professional routes such as publication.
+
+Building on this corpus to more specific pedagogical ends are: the ‘Working in Harmony’ app (offering automatic feedback on users’ Roman numeral analyses), and an associated Harmony Anthology I have produced for the Open Music Theory Textbook v2. This new kind of anthology harnesses computational methods to present a much larger collection of examples (deliberately including edge-cases), feature the work of many analysts, and provide links to full scores for all entries. This enables a freer exploration of historical harmonic languages and how they vary from composer to composer and over time.
+
+
+**4:30 PM (EDT) – Encoding Schnittke: A Co-Curricular Experiment in MEI – Joy Calico (Vanderbilt University), Jake Schaub (Anne Potter Wilson Music Library, Vanderbilt University)**
+
+In S2020 a music librarian and a musicology faculty member led a co-curricular seminar that taught four undergraduates to encode an Alfred Schnittke MS, recently acquired by their institution’s Special Collections, using the Music Encoding Initiative (MEI). Our intention was to use this seminar as the first step in a long-term project to develop a linked open data resource for research on Schnittke, and provide subsequent cohorts of students with an opportunity to learn music encoding skills while contributing to that project and fulfilling co-curricular research requirements.  This paper (1) describes the process whereby we developed the program using both institutional and external resources; (2) assesses our successes and failures, both pedagogical and programmatic; and (3) shares teaching materials that others could use to teach MEI in different classroom contexts.

--- a/_posts/2021-07-27-music-encoding-use-cases-in-us-libraries.md
+++ b/_posts/2021-07-27-music-encoding-use-cases-in-us-libraries.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title:  "Event: Music Encoding Use-cases in U.S. Libraries: Aims, Pedagogy, and Workflows"
+date:   2021-06-27 14:00
+categories: update
+---
+
+There is a session of interest to the MEI community on Tuesday, July 27 during the International Association of Music Libraries, Archives and Documentation Centres Congress (IAML) and Digital Libraries for Musicology Conference.
+
+**Music Encoding Use-cases in U.S. Libraries: Aims, Pedagogy, and Workflows**
+
+July 27, 2021, 19-20.30 UTC
+
+Presented by the Forum of Sections <br/>
+Chair: Anna E. Kijas <br/>
+Speakers: Anna E. Kijas (Tufts University), Maristella Feustle (University of North Texas), Jacob Schaub (Vanderbilt University), and David Day (Brigham Young University, Provo, UT)
+
+
+How are library professionals engaging with music encoding and why? What workflows have been developed to aid in teaching students or staff to transcribe and encode music? By “music encoding” we mean representing music notation in a standardized, machine-readable format. Librarians from four public and private U.S. academic institutions will present music encoding use cases that highlight particular aspects of their collections with a focus on pedagogical approaches, workflows, and choices of technology.
+
+At Tufts University, Lilly Music Library students are working on a music incipits project that aims to make compositions by un(der)-represented composers visible and discoverable. They are developing expertise in transcription and editing, and expanding their knowledge of a diverse music repertoire. Project aims, workflows, and pedagogical value of this work will be discussed.
+
+At Brigham Young University, students are involved in a harp music incipits project that aims to explore how incipits can be used 1) to provide enhanced metadata in online catalogs and/or the planned online harp repertory guide, 2) for analysis of the adaptation of popular songs and operatic arias in harp music arrangements, 3) to create online thematic catalogs for composers who wrote primarily for the harp, and 4)  potentially in RISM. The idea of encoding themes from Pierre Adolphe Capelle’s La clé du claveau will also be explored.
+
+The University of North Texas Music Library is pursuing multiple, complementary benefits through the encoding of early editions of operas and ballets by Jean-Baptise Lully and his sons. Encoding is the first step in unlocking possibilities for discovery, performance, study, and data analysis. A pilot project with one librarian and two graduate students at UNT has focused on encoding the scarcely performed opera Zéphire et Flore by Louis and Jean-Louis Lully, refining workflows and training materials for future plans to encode UNT’s extensive Lully collection.
+
+The Wilson Music Library at Vanderbilt University is exploring areas of MEI pedagogy as well as the potential and challenges of MEI application to contemporary musical manuscripts. In Spring 2020, a student library fellows seminar at Vanderbilt co-led by a music librarian and a musicology faculty member focused on equipping students with the basics of MEI as well as utilizing these tools toward the ongoing encoding of a 1994 working draft of Alfred Schnittke’s Sinfonisches Vorspiel held in Vanderbilt University Special Collections.
+
+These four use-cases will demonstrate the ways in which librarians are engaging with music encoding in ways that highlight aspects of their collections, generate music data for further analysis or research, and create an environment of praxis for students, staff, and faculty.


### PR DESCRIPTION
This PR adds the latest events to news including

1) Today's music encoding related session at Teaching Music History Conference 2021 (sorry for the delay)
2) the updated program website for MEC2021
3) the "Music Encoding Use-cases in U.S. Libraries" session at IAML/DLfM (will be posted on 27 June)

