### PR TITLE
Update conference program

### DIFF
--- a/_conferences/2021/program.html
+++ b/_conferences/2021/program.html
@@ -292,12 +292,12 @@ published: true
                 <br>(2) Johann Wolfgang Goethe-Universität Frankfurt</em>
         </li>
         <li>
-            <strong>Rendering the Psaltic (Byzantine) Notation for Greek Musical Repertories</strong>
+            <strong>Font Design of Psaltic (Byzantine) Notation for Greek Musical Repertories</strong>
             <br>Nikolaos Siklafidis, Maria Alexandru
             <br><em>Aristotle University Thessaloniki, Greece</em>
         </li>
         <li>
-            <strong>Regularising facsimile images of medieval manuscripts for machine learning enhanced transcription</strong>
+            <strong>Annotation of Medieval Music Facsimiles Using "Good Enough" OMR</strong>
             <br>Joshua Stutter
             <br><em>University of Glasgow, United Kingdom</em>
         </li>

--- a/_conferences/2021/program.html
+++ b/_conferences/2021/program.html
@@ -118,8 +118,8 @@ published: true
     
     <h3 id="keynotes">Keynote speakers</h3>
     <ul>
-        <li>Pip Willcox, Head of Research, The National Archives (UK)</li>
-        <li>Álvaro Torrente, Professor of Music History, Universidad Complutense de Madrid, and Director, Instituto Complutense de Ciencias Musicales, Spain. <a href="https://didone.eu/">Didone Project</a></li>
+        <li><strong>Álvaro Torrente</strong>, Professor of Music History, Universidad Complutense de Madrid, and Director, Instituto Complutense de Ciencias Musicales, Spain, <a href="https://didone.eu/">Didone Project</a> (<strong>with Ana Llorens</strong>, Instituto Complutense de Ciencias Musicales)<br/><i>The Musicology Lab: Teamwork and the Musicological Toolbox</i></li>
+        <li><strong>Pip Willcox</strong>, Head of Research, The National Archives (UK) <br/><i>Automatic for the People: archives and the future</i></li>
     </ul>
 
     <h3>Workshops</h3>


### PR DESCRIPTION
This small PR adds the titles of the keynotes, switches keynote order according to the conference schedule, and adds Ana Llorens as co-author. It also updates some poster titles that had changed after revision.

@davidrizo Could you please have a look?