### PR TITLE
Add bibliography to this page

### DIFF
--- a/resources/pedagogy.md
+++ b/resources/pedagogy.md
@@ -13,3 +13,11 @@ We will upload your resource(s) to the [Music Encoding Initiative Humanities Com
 If you would like to contribute a resource that you created or collaborated on, please [complete this form](https://docs.google.com/forms/d/e/1FAIpQLScnaXFQhtxVrt2aCaKqf0F4by_XgHHsvxhyq9-cvCDPE0j9vg/viewform) where you will need to provide descriptive metadata along with your content. Contributions can be submitted on a rolling basis and you will be notified once your content is added to the repository.
 
 If you have questions or need assistance, please reach out to the [Pedagogy Interest Group Administrative Co-Chairs](https://music-encoding.org/community/interest-groups.html), Anna Kijas and Joy H. Calico.
+
+## Selected Bibliography
+
+<div class="columns">
+    <div class="column col-12 bibliography">
+        <script src="https://bibbase.org/show?bib=https%3A%2F%2Fapi.zotero.org%2Fgroups%2F4439204%2Fitems%3Fkey%3D8lnTbafaItBb4ZVOjRCEYliR%26format%3Dbibtex%26limit%3D100&jsonp=1"&theme=dividers&nocache=1&authorFirst=1></script>
+    </div>
+</div>


### PR DESCRIPTION
We would like to add a bibliography generated in Bibtex from our Zotero library to appear at the bottom of the Pedagogy & Praxis page: https://music-encoding.org/resources/pedagogy.html.