### PR TITLE
fix(archive): redirect previous MEI versions to schema page

### DIFF
--- a/archive/index.md
+++ b/archive/index.md
@@ -13,30 +13,7 @@ Here you will find archived material, such as previous versions of MEI, document
 
 ## Previous Versions of MEI
 
-* [MEI (v. 3.0.0)](https://github.com/music-encoding/music-encoding/releases/tag/v3.0.0)
-  * MEI 3.0.0 Guidelines ([PDF](https://github.com/music-encoding/music-encoding/releases/download/v3.0.0/MEI_Guidelines_v3.0.0.pdf))
-  * RelaxNG schemata:
-    * [MEI All](../schema/3.0.0/mei-all.rng)
-    * [MEI All Anystart](../schema/3.0.0/mei-all_anyStart.rng)
-    * [MEI CMN](../schema/3.0.0/mei-CMN.rng)
-    * [MEI Mensural](../schema/3.0.0/mei-Mensural.rng)
-    * [MEI Neumes](../schema/3.0.0/mei-Neumes.rng)
-* [MEI 2013 (v. 2.1.1)](https://github.com/music-encoding/music-encoding/releases/tag/MEI2013_v2.1.1)
-  * MEI 2013 Guidelines ([PDF](https://github.com/music-encoding/music-encoding/releases/download/MEI2013_v2.1.1/MEI_Guidelines_2013_v2.1.1.pdf))
-  * RelaxNG schemata:
-    * [MEI All](../schema/2.1.1/mei-all.rng)
-    * [MEI All Anystart](../schema/2.1.1/mei-all_anyStart.rng)
-    * [MEI CMN](../schema/2.1.1/mei-CMN.rng)
-    * [MEI Mensural](../schema/2.1.1/mei-Mensural.rng)
-    * [MEI Neumes](../schema/2.1.1/mei-Neumes.rng)
-* [MEI 2012](https://github.com/music-encoding/music-encoding/releases/tag/MEI2012_v2.0.0)
-  * MEI 2012 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI2012_v2.0.0.zip))
-  * MEI 2012 Guidelines ([PDF](../downloads/MEI_Guidelines_2012_v2.0.0.pdf))
-* [MEI 2011-05](https://github.com/music-encoding/music-encoding/releases/tag/MEI_release_2011-05)
-  * MEI 2011-05 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI_release_2011-05.zip))
-* [MEI 2010-05](https://github.com/music-encoding/music-encoding/releases/tag/MEI_release_2010-05)
-  * MEI 2010-05 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI_release_2010-05.zip))
-  * Tag Library ([PDF](../downloads/MEI_TagLibrary_2010-05.pdf))
+* see [Schemas and Namespace](/resources/schemas.html)
 
 ## Workshop Materials
 

--- a/resources/schemas.md
+++ b/resources/schemas.md
@@ -25,3 +25,31 @@ In the context of tutorial exercises (or comparable purposes), the `MEI ALL (Any
 Further detailed customization of a schema, allowing to restrict specific elements or attributes, can be done with the MEI Garage profiler: [https://meigarage.edirom.de/profiler](https://meigarage.edirom.de/profiler).
 
 A detailed overview of the changes for the MEI 4.0 schema is available here: [https://music-encoding.org/archive/comparison-4.0.html](https://music-encoding.org/archive/comparison-4.0.html)
+
+
+# Previous Versions of MEI
+
+* [MEI (v. 3.0.0)](https://github.com/music-encoding/music-encoding/releases/tag/v3.0.0)
+    * MEI 3.0.0 Guidelines ([PDF](https://github.com/music-encoding/music-encoding/releases/download/v3.0.0/MEI_Guidelines_v3.0.0.pdf))
+    * RelaxNG schemata:
+        * [MEI All](../schema/3.0.0/mei-all.rng)
+        * [MEI All Anystart](../schema/3.0.0/mei-all_anyStart.rng)
+        * [MEI CMN](../schema/3.0.0/mei-CMN.rng)
+        * [MEI Mensural](../schema/3.0.0/mei-Mensural.rng)
+        * [MEI Neumes](../schema/3.0.0/mei-Neumes.rng)
+* [MEI 2013 (v. 2.1.1)](https://github.com/music-encoding/music-encoding/releases/tag/MEI2013_v2.1.1)
+    * MEI 2013 Guidelines ([PDF](https://github.com/music-encoding/music-encoding/releases/download/MEI2013_v2.1.1/MEI_Guidelines_2013_v2.1.1.pdf))
+    * RelaxNG schemata:
+        * [MEI All](../schema/2.1.1/mei-all.rng)
+        * [MEI All Anystart](../schema/2.1.1/mei-all_anyStart.rng)
+        * [MEI CMN](../schema/2.1.1/mei-CMN.rng)
+        * [MEI Mensural](../schema/2.1.1/mei-Mensural.rng)
+        * [MEI Neumes](../schema/2.1.1/mei-Neumes.rng)
+* [MEI 2012](https://github.com/music-encoding/music-encoding/releases/tag/MEI2012_v2.0.0)
+    * MEI 2012 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI2012_v2.0.0.zip))
+    * MEI 2012 Guidelines ([PDF](../downloads/MEI_Guidelines_2012_v2.0.0.pdf))
+* [MEI 2011-05](https://github.com/music-encoding/music-encoding/releases/tag/MEI_release_2011-05)
+    * MEI 2011-05 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI_release_2011-05.zip))
+* [MEI 2010-05](https://github.com/music-encoding/music-encoding/releases/tag/MEI_release_2010-05)
+    * MEI 2010-05 Release ([ZIP](https://github.com/music-encoding/music-encoding/archive/MEI_release_2010-05.zip))
+    * Tag Library ([PDF](../downloads/MEI_TagLibrary_2010-05.pdf))


### PR DESCRIPTION
This PR contributes to #131 by redirecting the archive's "Previous versions of MEI" section to the schema and namespace subpage (previous versions are listed there now).
