### PR TITLE
feat(conference): add keynote videos for MEC2021

### DIFF
--- a/_conferences/2021/keynotes.html
+++ b/_conferences/2021/keynotes.html
@@ -1,0 +1,18 @@
+---
+layout: conference
+title: "Keynote videos"
+permalink: "/conference/2021/keynotes/"
+tag: MEC2021
+id: keynotes
+---
+
+<img src="/images/conference/2021/mec2021_logo.jpg" class="img-responsive" alt="Music Encoding Conference, Universidad de Alicante, 25–28 May 2021"/>
+
+<div class="mec2021-page" style="margin-top:2em;">
+  <h1>Keynote videos</h1>
+  <p>The opening keynote of MEC 2021 has been recorded and is available online through YouTube.</p>
+
+  <h2>Keynote by Prof. Dr. Álvaro Torrente and Dr. Ana Llorens</h2>
+  <h3>The Musicology Lab: Teamwork and the Musicological Toolbox</h3>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/LF-NF98Pssk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>


### PR DESCRIPTION
This PR adds a keynote page to the MEC 2021 conference section with the embedded video of the opening keynote.