### PR TITLE
feat(conference): add mec 2021 proceedings

### DIFF
--- a/conference/mec_proceedings.bib
+++ b/conference/mec_proceedings.bib
@@ -1054,3 +1054,456 @@
  keywords = {mec-proceedings, mec-proceedings-2020},
  displayby = {Contributions from MEC 2020}
 }
+
+
+
+%%% -------------------------------------
+%%% MEC 2021 Proceedings: Full volume
+
+@proceedings{Muennich-Rizo_2022a,
+ abstract = {Conference proceedings of the Music Encoding Conference 2021 with Foreword by Stefan M{\"u}nnich and David Rizo.},
+ year = {2022},
+ title = {{Music Encoding Conference Proceedings 2021}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ doi = {10.17613/fc1c-mx52},
+ bibbase_note = {<span style="color: green; font-weight: bold">Full volume.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% ------------------------------
+%%% MEC 2021 Proceedings: Foreword
+
+@inproceedings{Muennich-Rizo_2022b,
+ abstract = {Foreword of the Music Encoding Conference 2021 proceedings.},
+ author = {M{\"u}nnich, Stefan and Rizo, David},
+ title = {{Foreword}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {vii--viii},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/f1b1-zv67},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% -------------------------------
+%%% MEC 2021 Proceedings: Keynote I
+
+@inproceedings{Torrente-LLorens_2022,
+ abstract = {Musicology is a small discipline within the wide spectrum of human knowledge, yet it is already divided into various branches, each with its own societies, conferences, journals, jargons, degrees, prejudices, $\ldots$, and jobs. Although they share their object of investigation -- ``the art of music as a physical, psychological, aesthetic, and cultural phenomenon'' --, these branches very often ignore one another. Research in musicology is mostly a solitary task, as investigations, papers, and publications are commonly signed by single authors, in contrast with STEM disciplines where teamwork is the rule. This is in part the result of tradition -- the ``Musicological Toolbox'' -- but also the aftermath of the job market and financing programs.
+
+Large funding schemes such as the European Research Council (ERC) grants are becoming a major disruptive factor in many disciplines in the humanities, including musicology. Scholars in all fields now have the opportunity to build research teams, and most of their members receive their salaries to exclusively work on the project. In other words, we are starting to build what could be called a Musicology Lab, learning along the way how teamwork is reshaping and transforming the Musicological Toolbox, the look and feel of our discipline, the way we work as well as the way we publish and disseminate our results.
+
+This paper presents some of the key features of the ERC Didone project, one of its principal tasks being to create a digitally encoded corpus of some 3,000 arias in MusicXML format from about 180 musical settings of a small number of opera librettos by Pietro Metastasio. It focuses on some of the project's research tasks, emphasizing how the skills of a team of eighteen scholars with very different expertise -- historical musicology, music theory and analysis, cultural history, librettology, archival research, music performance, music engraving, MIR, computer science, and statistical modeling -- combine to explore the potential answer(s) to the main research question of the project: How are emotions expressed through music?},
+ author = {Torrente, {\'A}lvaro and Llorens, Ana},
+ title = {{The Musicology Lab: Teamwork and the Musicological Toolbox}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {9--20},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/kmjq-pb94},
+ bibbase_note = {<span style="color: green; font-weight: bold">Keynote I.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% -------------------------------
+%%% MEC 2021 Proceedings: Papers
+
+@inproceedings{RosFabregas_2022,
+ abstract = {This paper presents the recent implementation of encoded music notation in two open access platforms of the Spanish National Research Council (CSIC) devoted to traditional music and polyphony, respectively: Fondo de M{\'u}sica Tradicional IMF-CSIC (FMT)1 and Books of Hispanic Polyphony IMF-CSIC (BHP)2. Even though, at first, both repertories seem unconnected, they have many textual/literary and musical points in common -- such as the presence/survival of old 15th--17th century texts and/or melodies of polyphonic romances (ballads) in the 20th century oral tradition --; future technological developments will facilitate further connections beyond the ones already found through search by text incipits and numeric melodic incipit connecting both platforms. The presentation will have two parts devoted to FMT (with more than 20.000 images of melodies in open access, it is the largest online archive of folklore in the Hispanic world; it is used also for OMR research) and BHP (a reference online catalogue for polyphonic choir books in Spain and books with Hispanic polyphony elsewhere). After a brief explanation about the origin and scope of the repertories covered in each platform, a few examples of encoded transcriptions of a melody, of an incipit in mensural notation, and of a polyphonic work (in MusicXML, **mens, and **kern; MEI can be used, too) rendered through Verovio will illustrate the potential development of FMT and BHP. Both websites constitute leading educational and musicological resources of the very rich Spanish music heritage, inviting national and international collaboration (crowdsourcing) to expand the contents of both platforms and to develop their digital technology.},
+ author = {Ros-F{\'a}bregas, Emilio},
+ title = {{Encoded Spanish Music Heritage through Verovio: The Online Platforms \textit{Fondo de M{\'u}sica Tradicional IMF--CSIC} and \textit{Books of Hispanic Polyphony IMF--CSIC}}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {21--29},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/m2ny-6b18},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Goebl_2022,
+ abstract = {Though MEI is widely used in music informatics and digital musicology research, the relative lack of authoring software and the specialised nature of its community have limited the availability of high-quality MEI encodings. Translating to MEI from other encoding formats, or generating MEI via optical music recognition processes, is thus a typical component of many MEI-project workflows. However, automated translations rarely achieve results of sufficient quality, a problem well-known in the community and documented in the literature. Final correction and validation by hand is therefore a common requirement. In this paper, we present meifriend, an extension to the Atom text editor, which aims to relieve the degree of manual labour required in this process. The tool facilitates most common MEI editing tasks including the insertion and manipulation of MEI elements, makes the encoded score visible and interactively accessible to the user, and provides quality-of-life conveniences including keyboard shortcuts for editing functions as well as intelligent navigation of the MEI hierarchy. We detail the tool's implementation, describe its functionalities, and evaluate its responsiveness during the editing process, even when editing very large MEI files.},
+ author = {Goebl, Werner and {M. Weigl}, David},
+ title = {{Alleviating the Last Mile of Encoding: The \textit{mei-friend} Package for the Atom Text Editor}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {31--39},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/45ag-v044},
+ bibbase_note = {<span style="color: green; font-weight: bold">Best Paper Award.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Rettinghaus_2022,
+ abstract = {Digital symbolic music scores offer many benefits compared to paper-based scores, such as a flexible dynamic layout that allows adjustments of size and style, intelligent navigation features, automatic page-turning, on-the-fly modifications of the score including transposition into a different key, and rule-based annotations that can save hours of manual work by automatically highlighting relevant aspects in the score. However, most musicians still rely on paper because they don't have access to a digital version of their sheet music, or their digital solution does not provide a satisfying experience. To bring digital scores to millions of musicians, we at Enote are building a mobile application that offers a comprehensive digital library of sheet music. These scores are obtained by a large-scale Optical Music Recognition process, combined with metadata collection and curation. Our material is stored in the MEI format and we rely on Verovio as a central component of our app to present scores and parts dynamically on mobile devices. This combination of the expressiveness of MEI with the beautiful engraving of Verovio allows us to create a flexible, mobile solution that we believe to be a powerful and true alternative to paper scores with practical features like smart annotations or instant transpositions. We also invest heavily into the open-source development of Verovio to make it the gold standard for rendering beautiful digital sheet music.},
+ author = {Rettinghaus, Klaus and Pacha, Alexander},
+ title = {{Building a Comprehensive Sheet Music Library Application}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {41--48},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/s315-2y29},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Lewis_2022,
+ abstract = {Music and the scholarship around it can be challenging to present in the forms associated with books and articles -- primarily linear and with an emphasis on the static and visual over the sonic and interactive. We introduce the Lohengrin TimeMachine, a multiple-path multimedia app, optimised for a touch-screen tablet. The app offers two essays about motifs in the opera -- one in textual form, and one a 30-minute video. These linear narratives are supported by audio examples, along with dynamic links that take the reader into a fully-interactive exploration of the occurrence of motifs across the opera. The reader's journey is supported with recorded music and scores, as well as novel visualisations of the orchestration and the timeline of the opera. The app is designed to operate over standards-based web documents published online, with extension and reuse in mind. In this paper, we describe the app, its underlying technology, and the journeys it supports.},
+ author = {Lewis, David and Page, Kevin R. and Dreyfus, Laurence},
+ title = {{\textit{Lohengrin TimeMachine}: Musicological Multimedia Made with MELD}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {49--55},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/kggk-pz64},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Berndt_2022,
+ abstract = {With Music Performance Markup (MPM) we introduce a new XML format for describing musical performances in a systematic way. The format builds upon a series of mathematical models that capture the characteristics of performance features such as continuous tempo and dynamics transitions, articulations, and metrical accentuations. Bundled with MPM comes an infrastructure of documentations and software tools. This paper aims to provide an overview of and introduction to MPM, its infrastructure and ongoing development activities.},
+ author = {Berndt, Axel},
+ title = {{Music Performance Markup: Format and Software Tools Report}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {57--63},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/s357-e217},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Martignano_2022,
+ abstract = {The ERC funded project European Ars Nova aims to study the corpus of poetry in Latin, Italian and French set to music by the polyphonists of the so-called Ars Nova. Since one of the main research goals of the project is the comparative study of musical and poetic texts, we are currently developing a web application that will allow readers to visualize and interact with the TEI- and MEI-encoded editions of our corpus together. The adoption of MEI as the underlying format for the digital editions of the musical texts presented us with the challenge of designing an editing workflow that allowed us to critically edit the texts in a user-friendly software like Finale. In this article, we illustrate how the critical editions are transposed to MEI documents using an ad hoc tool developed within the project, and how they are visualized in the web application. Finally, we discuss the critical aspects of the workflow and possible next steps for our digital critical edition in relation to the state of the art of music encoding.},
+ author = {Martignano, Chiara and Calvia, Antonio and Epifani, Michele},
+ title = {{Tools and Perspectives for a Digital Critical Edition of Fourteenth-Century Polyphonic Music}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {65--74},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/mnk2-yd48},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{GonzalezGutierrez_2022,
+ abstract = {This paper aims to highlight, as a case study, the encoding of a Spanish traditional music corpus using the MEI standard for the development of an interactive traditional music database focused on preserving and disseminating this type of cultural expression in the field of music education as well as ethnomusicology research. It analyzes the possibilities of the schemas and the guidelines followed to describe cancioneros at the bibliographic level, as an archetypal form of compiling traditional music in Spain, as well as the analytical aspects that highlight paradigmatic elements of this kind of music such as rhythmic patterns, tessituras, modal contexts, phrases, structural forms, etc.},
+ author = {{Gonz{\'a}lez Guti{\'e}rrez}, Sara and {Merch{\'a}n S{\'a}nchez-Jara}, Javier and {Navarro C{\'a}ceres}, Mar{\'i}a},
+ title = {{Encoding Traditional Spanish Music for Pedagogical Purposes Through MEI: Challenges and Opportunities}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {75--84},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/w639-8t53},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Kepper_2022,
+ abstract = {Traditional music philology aims at establishing an edited text, which is supposed to stage a clearly identified and well-reasoned version of a musical work. Such a text will always depend on sources used for its preparation and decisions taken by the editor(s). However, the intention is to deliver a product -- a static text, which resembles a specific combination of the transmitted sources of the work in question. In Genetic Editing, the focus lies elsewhere: Instead of justifying a specific product version, the intention is to trace the creative processes involved in the composition of that work. Obviously, those processes are only accessible through transmitted documents as well, but those documents do not need to contain full texts, nor are they only relevant when the composition has already matured enough to more or less reflect the final work.
+
+The Beethovens Werkstatt project is one of the first endeavors to explore the applicability of Genetic Editing to music. Several years ago, a presentation at MEC 2015 in Florence introduced the first findings of the project and illustrated the then novel approaches of encoding genetic processes in MEI [2]. The discussions of the conceptual model proposed there eventually led to the introduction of several new elements into MEI. Since then, not only MEI has evolved, but also the project. The paper at hand reflects on data model considerations for the project's current module.},
+ author = {Kepper, Johannes and Cox, Susanne},
+ title = {{Encoding Genetic Processes II}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {85--95},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/q6y4-9139},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Gubsch_2022,
+ abstract = {Metadata are a very broad and extremely differentiated subject and ranges from rudimentary catalog data to deeply indexed scientific catalogs (e.g., catalogs of works). In this paper, the concept of metadata in the context of MEI is first examined, before two examples are used to show that metadata are more than just rudimentary descriptions. These examples are also intended to illustrate the extent to which metadata are encoded in the field of music philology and thus represent an attempt to create a little more awareness for the work of the Metadata and Cataloging Interest Group of MEI.
+
+The examples deal on the one hand with the encoding of performance resources and on the other hand with watermarks. In both cases, the possibilities of metadata encoding with MEI version 4 are exhausted and it is discussed which steps are useful and necessary to create an even deeper, machine-readable structure so that these sub-fields of the MEI metadata can also be used for larger scientific purposes such as analyses.},
+ author = {Gubsch, Clemens and Ried, Dennis},
+ title = {{METAdata and metaDATA}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {97--105},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/50t9-z881},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Richts-Matthaei_2022a,
+ abstract = {Library forms of cataloging may differ greatly from the cataloging requirements of musicological research projects: They are often not detailed enough and do not take a close enough look at aspects of content relevant to research, such as handwritten entries in materials, etc. Library catalog entries of individual documents stand on their own for historical reasons, but usually do not reflect relationships to other surviving materials. This observation was the starting point for the Detmold Court Theatre Project, a six-year research project (September 2014 -- January 2021) that looked at the interconnectedness of different surviving materials of a 19th century theatre company that existed from 1825 to 1875. This project dealt with a very detailed form of inventory indexing in order to hand over and make accessible the formerly related materials in their entirety. This form of indexing was called `contextual deep indexing'. This special form of indexing took into account not only the pure performance materials but also the surviving theatre files, such as fee books, revenue and expense documents, stock lists, director's books, role and costume books, etc. All information was recorded based on autopsy (in the case of musical records on the basis of already existing RISM records from the 1980s). It was the first attempt to carry out such a form of indexing on the basis of the MEI and TEI encoding standards for a large repertory. For this purpose, a data model was needed that focuses on the linking of MEI and TEI data and enables the linking of different surviving library holdings, with a focus on a FRBR-based indexing of performance materials and associated performers as well as the structure of the theatre. Using a custom ODD-based schema, separate records were created for all works, expressions, and manifestations (in this case preserving the unity of materials kept under a common signature) and given unique identifiers so that they can now all be referenced individually.
+
+The paper summarizes the results of this pilot project. It addresses the particularities and requirements of an inventory development that does not focus on individual objects, but on the relationship between different objects (and subjects). It presents a document-oriented (not object-oriented) data model that uses library materials to revive an entire network of a long-gone organization.},
+ author = {Richts-Matthaei, Kristina and Capelle, Irmlind},
+ title = {{United, Linked, Connected -- A Data Model for the Inventory of the Former Detmold Court Theatre (1825--1875), or: How Library Inventory History Can also Be Told}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {107--115},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/bqd1-yf81},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Page_2022,
+ abstract = {Performance of music in the home was the means by which most works were received before the advent of audio recordings and broadcasts, yet the notation sources that form our primary record of this culture have not been the subject of comprehensive or methodical study. Choices made by arrangers adapting music for domestic consumption -- of instrumentation, abbreviation, or simplification -- reflect the musical life of the 19th century, and can inform our understanding alongside contemporary accounts such as newspapers, adverts, and diaries.
+
+This position paper gives the background, motivation, and proposed approach of research currently being undertaken within the Beethoven in the House project. This will include a study of Steiner editions of Beethoven's 7th and 8th Symphonies and Wellingtons Sieg, making a detailed comparison between arrangements, systematically identifying a core common to multiple versions, and asking if this reflects the stated values of the publisher. A second survey will look for patterns across a larger sample of lesser-known and poorly catalogued scores, collating emergent indicators of arrangers' motivations within a narrative of the domestic market -- the music industry of its day. Both studies will innovate digital methods which characterise arrangements as music encodings, including `sparse' approaches to notation and annotation.},
+ author = {Page, Kevin R. and Kepper, Johannes and Siegert, Christine and Hankinson, Andrew and Lewis, David},
+ title = {{Beethoven in the House: Digital Studies of Domestic Music Arrangements}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {117--123},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/389b-xx73},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% -------------------------------
+%%% MEC 2021 Proceedings: Posters
+
+@inproceedings{Albuquerque_2022,
+ abstract = {PROFMUS is a collaborative project that aims to carry out the research and consolidation of information to support further research about the Portuguese musicians active in the period from 1750 to 1986. The information to be collected must include as many relevant attributes as possible, especially about their academic background, professional careers, and personal details. This project considers a large amount of data from a wide time-period, which means there will be various attributes for each object, which will evolve over time or differ from source to source. There is also an issue wit the lack of uniformity of existing sources in multiple institutions, museums, archives, and databases, each with its own data scheme. Since PROFMUS has a long-term perspective, it does not try to create a uniform and prefixed scheme for the data to consolidate but accepts every different scheme and stores all data in a controlled knowledge base. We describe here an application for that purpose, using MediaWiki and Wikibase for storage, and a back-office specific application to manage and publish the data.},
+ author = {Albuquerque, Maria Jo{\~a}o and Pinto, H. Sofia and Borbinha, Jos{\'e} Lu{\'i}s},
+ title = {{The PROFMUS Application: Development, Status, and Future Progress}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {125--130},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/7wd6-1x56},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Gotham_2022,
+ abstract = {The OpenScore Lieder Corpus is a collection of over 1,200 nineteenth century songs encoded by a dedicated team of mostly volunteers over several years. Having reported on the initial phase, motivations, design, and community-oriented aspects of the project before, we present here the first, stable, large-scale release of this corpus specifically designed for MIR researchers, complete with comprehensive, structured, linked metadata. The corpus continues to be available under the open CC0 licence and represents a compelling dataset for a range of MIR tasks, not least given its unusual balance of large-scale with high-quality encoding, and of diversity (songs by over 100 composers, from many countries, and in a range of languages) with unity (centred on the nineteenth-century lieder tradition).},
+ author = {Gotham, Mark Robert Haigh and Jonas, Peter},
+ title = {{The OpenScore Lieder Corpus}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {131--136},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/1my2-dm23},
+ bibbase_note = {<span style="color: green; font-weight: bold">Best Poster Award.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+
+@inproceedings{Richts-Matthaei_2022b,
+ abstract = {NFDI4Culture is the consortium for research data on material and immaterial cultural heritage and offers a user-centered and research-led infrastructure. By focusing on the digital capture as well as data-based research of cultural assets, NFDI4Culture brings together different disciplines in their research interests but also in terms of their infrastructure needs. The consortium has been funded since October 2020 for an initial period of 5 years. Paderborn University is connected to NFDI4Culture via the Center for Music, Edition, Media (Zen-MEM), which bundles activities in the fields of digital musicology, music and film informatics, media science, media technologies, and in several areas of computer science with a special focus on Digital Music Edition and Digital Musicology. With its many projects, ZenMEM contributes a lot to the further development of MEI.
+
+MEI will therefore also have a special place in NFDI4Culture. In addition to general community aspects and enhancements of the format, activities will focus on the development of best practice recommendations and training materials, the further development of MEI-related tools, such as MerMEId and the MEIGarage, and concepts for data quality in MEI, but also on the improvement of standard data for musical works. The poster will show the organizational structure of NFDI4Culture and its representation at Paderborn University, its interaction and networking with national and international infrastructures, combined with several examples where MEI is involved.},
+ author = {Richts-Matthaei, Kristina and Albrecht-Hohmaier, Martin and R{\"o}wenstrunk, Daniel and M{\"u}nzmay, Andreas},
+ title = {{MEI Meets NFDI4Culture}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {137--141},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/ny4d-bp67},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Hentschel_2022,
+ abstract = {Chord-based harmony is an important aspect of many types of Western music, across genres, regions, and historical eras. However, the consistent representation and comparison of harmony across a wide range of styles (e.g., classical music, Jazz, Rock, or Pop) is a challenging task. Moreover, even within a single musical style, multiple theories of harmony exist, each relying on its own (possibly implicit) assumptions and leading to harmonic analyses with a distinct focus (e.g., on the root of a chord vs. its bass note) or representation (e.g., spelled vs. enharmonic pitch classes). Cross-stylistic and cross-theory comparisons are therefore even more difficult, particularly in a large-scale computational setting that requires a common overarching representation. To address these problems, we propose a model which allows for the representation of chords at multiple levels of abstraction: from chord realizations on the score level (if available), to pitch-class collections (including a potential application of different equivalences, such as enharmonic or octave equivalence), to pitch- and chord-level functions and higher-order abstractions. Importantly, our proposed model is also well-defined for theories which do not specify information at each level of abstraction (e.g., some theories make no claims about harmonic function), representing only those harmonic properties that are explicitly included and inducing others where possible (e.g., deriving scale degrees from root and key information). Our model thus represents an important step towards a unified representation of harmony and its various applications.},
+ author = {Hentschel, Johannes and Moss, Fabian C. and McLeod, Andrew and Neuwirth, Markus and Rohrmeier, Martin},
+ title = {{Towards a Unified Model of Chords in Western Harmony}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {143--149},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/4crx-fr36},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Lind_2022,
+ abstract = {Musical scores are frequently annotated with harmonic information, but widely used text-based methods rely on a limited number of visual channels. Though glyph-based methods exploit more channels, existing systems often violate perceptual design principles when employing color and rarely capture the frequency of chordal changes or their harmonic function. In this work, we introduce a new design idiom for augmenting sheet music through chordal glyphs embedded directly within musical staves. Harmonic concepts, weighted by saliency and categorized by data type, are mapped to visual channels ranked by discriminability. Preattentive processing is leveraged to support various user tasks, alongside redundant encodings of foundational harmonic elements to improve overall perceptual effectiveness. Key names and chord roots are displayed using parallel hue-based 12-step categorical colormaps. We then distill several design implications inherent in assigning colors to musical pitches regarding perceptual and linguistic effectiveness. Following this discussion, we outline open research directions.},
+ author = {Lind, Justin},
+ title = {{Visualizing Harmony Using Chordal Glyphs and Color Mapping}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {151--158},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/taak-jv92},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Matuszewska_2022,
+ abstract = {The field of musicology is constantly being enriched with digital, searchable music data. This trend opens new research possibilities; conversely, it requires new abilities to work with numerous data sets efficiently. Digital tools facilitate searching large music corpora and serve music analysis well. Nevertheless, there is still a potential to better harmonize research perspectives from musicology and computer science to make computational analysis outcomes more explicit, comprehensible, and flexible.
+
+The aim of this paper is to present new ways of handling, displaying, and considering musicological data. Music information from fugues BWV 846--851 composed by J.S. Bach, retrieved with Humdrum Tools and the Music Processing Suite (MPS) software, was processed and translated into a relational database. The visual display of the retrieved information was accomplished with dashboards using the data visualization software Tableau Public. The possibility of comparing each fugue's voices makes it easier to comprehend the knowledge hidden behind music data. Additional options enable further visual exploration of the analyses and ensure conditions for abduction under assumptions of diagrammatic reasoning as proposed by Charles Sanders Peirce.},
+ author = {Matuszewska, Anna and Seibert, Christoph},
+ title = {{Diagrammatic Analysis of J.S. Bach's \textit{The Well-Tempered Clavier} Fugues, BWV 846--851}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {159--166},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/j7vc-cq22},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Bohl_2022,
+ abstract = {In the past twenty years, the technical setup of the Music Encoding Initiative (MEI) data framework has been adjusted several times. Each of those transitions was motivated by the wish to improve the ways in which MEI could be integrated with other formats, to simplify the maintenance of MEI, and to encourage more people to actively contribute to the development of MEI. Some of those objectives are contradictory, and accordingly, there is no single right answer for all times about the best possible technical setup for MEI. The main purpose of this poster is to give a historical overview of the technical setups that MEI has gone through in the 20 or so years of its existence, and to illustrate the current workflows. Ideally, this empowers wider parts of the community to contribute to the continued development of both the MEI specification and documentation. Eventually, it will explain the steps necessary to set up a local working environment to participate in these developments.},
+ author = {Bohl, Benjamin W. and Kepper, Johannes},
+ title = {{ODD Structures and Where to Find Them}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {167--171},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/fjmt-xs81},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Siklafidis_2022,
+ abstract = {The possibility of rendering scores of Greek Chant repertoires from the 3rd to the 21st century A.D. with the use of the computer opens new horizons in musicological research. In this poster a synoptic overview concerning the historical development of notational types used for Greek chants is given. This is followed by a record of various fonts and software for Byzantine neumes created since 1989. The goal of the poster is to present a new font for psaltic notations of the first and second Christian millennium, displaying the great variety of signs, neume families and neume combinations which are encountered in musical manuscripts and theoretical treatises of the Psaltic Art. These by far exceed the Byzantine neumes found today in the unicode system.
+
+The future development of suitable software can facilitate interdisciplinary studies with other traditions and contribute to the communication between musicologists and musicians belonging to different areas of expertise.},
+ author = {Siklafidis, Nikolaos and Alexandru, Maria},
+ title = {{Font Design of Psaltic (Byzantine) Notation for Greek Musical Repertoires}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {173--180},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/cwz0-st26},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Stutter_2022,
+ abstract = {The Clausula Archive of the Notre Dame Repertory (CANDR) is an in-progress PhD project with the aim of cataloguing, transcribing and analysing digital facsimiles of the thirteenth-century repertory commonly termed Notre Dame polyphony, and a secondary aim of providing new datasets and analytical tools for studying medieval polyphony. This poster highlights the use in the project of (a) a new methodology for de-skewing facsimile images, and (b) average symbol masks in an OMR--enhanced workflow with an emphasis on creating an OMR workflow that is `good enough' to accelerate the annotation of an image dataset of particularly transitional notation.},
+ author = {Stutter, Joshua},
+ title = {{Annotation of Medieval Music Facsimiles Using `Good Enough' OMR}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {181--187},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/5ssz-2n19},
+ displayby = {Contributions from MEC 2021}
+}
+
+
+@inproceedings{Zwissler_2022,
+ abstract = {A perspective on the specific issues of music encoding dealing with Electronic Music is presented. In many cases the works to be discussed exist in a fixed media format and hence no prescriptive score is necessary to facilitate a `valid' performance. While there are a number of descriptive scores for pieces of Electronic Music, these are to be treated differently, as they are purely aimed at analysis and therefore contain a certain information bias. Data that is more comparable to instrumental scores is contained in rare examples of so-called realization scores. It is argued that these realization scores can be identified as the main subject for encoding of Electronic Music works. For this we will discuss an example from one such score by Karlheinz Stockhausen. For his piece KONTAKTE, Stockhausen released a realization score that unfolds a very detailed documentation of all steps made within the studio production of that work, including the complex patching of studio devices and the specific transformation processes achieved by the use of tape machines. The paper presents an approach to formalize and encode all these steps within the framework of a semantic database. Using technology like the semantic web standard, Linked Data and the corresponding RDF/OWL framework, an Electronic Music production setup and its usage can be encoded, stored, and analyzed.},
+ author = {Zwi{\ss}ler, Florian and Schwarzbauer, Philip and Oehler, Michael},
+ title = {{Encoding Scores for Electronic Music}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {189--196},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/kmca-m064},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% -------------------------------
+%%% MEC 2021 Proceedings: Panel
+
+@inproceedings{Desmond_2022,
+ abstract = {This panel submission for the 2021 Music Encoding Conference brings together five short papers that focus on the making of computer-readable encodings of polyphony in the notational style -- mensural notation -- in which it was originally copied. Mensural notation was used in the medieval West to encode polyphony from the late thirteenth to sixteenth centuries. The Measuring Polyphony (MP) Online Editor, funded by an NEH Digital Humanities Advancement Grant, is a software that enables non-technical users to make Humdrum and MEI encodings of mensural notation, and links these encodings to digital images of the manuscripts in which these compositions were first notated. Topics explored by the authors include: the processes of, and the goals informing, the linking of manuscript images to music encodings; choices and compromises made in the development process of the MP Editor in order to facilitate its rapid deployment; and the implications of capturing dual encodings -- a parts-based encoding that reflects the layout of the original source, and a score-based encoding. Having two encodings of the music data is useful for a variety of activities, including performance and analysis, but also within the editorial process, and for sharing data with other applications. The authors present two case studies that document the possibilities and potential in the interchange of music data between the MP Editor and other applications, specifically, MuRET, an optical music recognition (OMR) tool, and Humdrum analysis tools.},
+ author = {Desmond, Karen and Pugin, Laurent and Regimbal, Juliette and Rizo, David and Sapp, Craig and Thomae, Martha E.},
+ title = {{Encoding Polyphony from Medieval Manuscripts Notated in Mensural Notation}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {197--219},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/tf2j-x697},
+ bibbase_note = {<span style="color: green; font-weight: bold">Panel.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+
+%%% -------------------------------
+%%% MEC 2021 Proceedings: Keynote II
+
+@inproceedings{Willcox_2022,
+ abstract = {Drawing on collaborative research at The National Archives, including through the UK Arts and Humanities Research Council's programme Towards a National Collection, this talk explores computational archival science, artificial intelligence, citizen involvement, and post-custodial approaches to challenge doom-laden technological determinism, and how together we might combine `hand-curated' and `at-scale' approaches to our shared cultural heritage to ensure automation works `for the people'.},
+ author = {Willcox, Pip},
+ title = {{Automatic for the People: Archives and the Future}},
+ keywords = {mec-proceedings, mec-proceedings-2021},
+ pages = {221},
+ publisher = {{Humanities Commons}},
+ isbn = {978-84-1302-173-7},
+ editor = {M{\"u}nnich, Stefan and Rizo, David},
+ booktitle = {{Music Encoding Conference Proceedings 2021}},
+ year = {2022},
+ doi = {10.17613/3stx-3f16},
+ bibbase_note = {<span style="color: green; font-weight: bold">Keynote II.</span>},
+ displayby = {Contributions from MEC 2021}
+}
+

--- a/conference/mec_proceedings.bib
+++ b/conference/mec_proceedings.bib
@@ -1070,7 +1070,7 @@
  editor = {M{\"u}nnich, Stefan and Rizo, David},
  doi = {10.17613/fc1c-mx52},
  bibbase_note = {<span style="color: green; font-weight: bold">Full volume.</span>},
- displayby = {Contributions from MEC 2021}
+ displayby = {Common part MEC 2021}
 }
 
 %%% ------------------------------
@@ -1088,7 +1088,7 @@
  booktitle = {{Music Encoding Conference Proceedings 2021}},
  year = {2022},
  doi = {10.17613/f1b1-zv67},
- displayby = {Contributions from MEC 2021}
+ displayby = {Common part MEC 2021}
 }
 
 %%% -------------------------------

--- a/conference/proceedings.md
+++ b/conference/proceedings.md
@@ -8,6 +8,14 @@ title: "Proceedings"
 <div class="columns">
     <div class="column col-12 mec-proceedings">
         <div class="mec-proceedings-section">
+            <div class="mec-proceedings-section-divider"><span>2021</span></div>
+            <div id="mec-proceedings-2021">
+                <div class="mec-proceedings-entries">
+                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-2021&group0=displayby"></script>
+                </div>
+            </div>
+        </div>        
+        <div class="mec-proceedings-section">
             <div class="mec-proceedings-section-divider"><span>2020</span></div>
             <div id="mec-proceedings-2020">
                 <div class="mec-proceedings-entries">


### PR DESCRIPTION
This PR adds bib files for the MEC 2021 proceedings to be listed on the website.

Output can be checked here for now: https://musicenfanthen.github.io/bibbase-test/

@davidrizo Can you have a look please?