### PR TITLE
Update technical team page

### DIFF
--- a/community/technical-team.md
+++ b/community/technical-team.md
@@ -8,7 +8,6 @@ The Technical Team consists of interested developers and two Board-appointed Co-
 
 * **Benjamin W. Bohl (Technical Co-Chair)**, Institut für Musikwissenschaft, Goethe Universität Frankfurt, Frankfurt am Main and Musikwissenschaftliches Seminar Detmold/Paderborn
 * **Stefan Münnich (Technical Co-Chair)**, Anton Webern Gesamtausgabe, University of Basel
-
 * **Sophia Dörner**, Humboldt-Universität zu Berlin
 * **Ichiro Fujinaga**, McGill University, Montréal
 * **Andrew Hankinson**, RISM Digital Center, Bern

--- a/community/technical-team.md
+++ b/community/technical-team.md
@@ -20,3 +20,67 @@ The Technical Team consists of interested developers and two Board-appointed Co-
 * **Martha E. Thomae**, McGill University, Montréal
 * **Raffaele Viglianti**, Maryland Institute for Technology in the Humanities
 * **Thomas Weber**, Notengrafik Berlin GmbH
+
+
+## MEI ODD meetings
+
+MEI ODD Fridays and ODD Thursdays are a monthly video conference call with anyone interested in the development of MEI. During these calls, we discuss open pull requests with additions to and revisions of both the MEI Schema and Guidelines. There are two requirements for accepting changes:
+
+* There have to be matching proposals for both the Schema and the Guidelines (i.e., changes without proper documentation won't get accepted, but may collect feedback),
+* there needs to be wide acceptance for these changes at the meetings and in the corresponding PRs.
+
+If a proposal doesn't match these two criteria, it will be postponed and should be revised for the next ODD meeting.
+
+We aim to organize, schedule, and document these meetings with the help of a GitHub dashboard: https://github.com/orgs/music-encoding/projects/2. We also plan to send out timely reminders in advance of these meetings. The intention is to increase both comprehensibility and transparency of the MEI development workflow, and make it more accessible and inviting to newcomers.
+
+The schedule for these developer workshops is the _last Friday of every odd month_, and _last Thursday of every even month_, at 1pm UTC (in summer) resp. 2pm UTC (in winter). Calls are scheduled for:
+
+
+
+**2022**
+* November 25, 2022 [2pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221125T140000&p1=1440) ODD Friday
+* October 27, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221027T130000&p1=1440) ODD Thursday
+* September 30, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220930T130000&p1=1440) ODD Friday
+* August: Summer break
+* July 29, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220729T130000&p1=1440), ODD Friday
+* June 24, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220624T130000&p1=1440) ODD Thursday
+* May 27, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220527T130000&p1=1440), ODD Friday
+* April 28, 2022 [1pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220428T130000&p1=1440) ODD Thursday
+* March 25, 2022 [2pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220325T140000&p1=1440) ODD Friday
+* February 24, 2022 [2pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220224T140000&p1=1440) ODD Thursday
+* January 28, 2022 [2pm UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220128T140000&p1=1440) ODD Friday
+
+<details>
+  <summary>ODD meetings in 2021</summary>
+
+  * November 26, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20211126T150000&p1=1440">3pm UTC</a> ODD Friday <br/>
+  * October 28, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20211028T140000&p1=1440">2pm UTC</a> ODD Thursday <br/>
+  * September 24, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210924T130000&p1=1440">1pm UTC</a> ODD Friday <br/>
+  * July (to be announced: during MEC, 19-22 July), ODD Friday <br/>
+  * June 24, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210624T130000&p1=1440">1pm UTC</a> ODD Thursday <br/>
+  * May 28, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210528T130000&p1=1440">1pm UTC</a> ODD Friday <br/>
+  * April 29, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210429T130000&p1=1440">1pm UTC</a> ODD Thursday <br/>
+  * March 26, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210326T130000&p1=1440">1pm UTC</a> ODD Friday <br/>
+  * February 25, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210225T130000&p1=1440">1pm UTC</a> ODD Thursday <br/>
+  * January 29, 2021, <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210129T130000&p1=1440">1pm UTC</a> ODD Friday <br/>
+</details>
+
+<details>
+  <summary>ODD meetings in 2020</summary>
+
+  * November 27, 2020, 1pm UTC ODD Friday <br/>
+  * October 29, 2020, 1pm UTC ODD Thursday <br/>
+  * September 25, 2020, 1pm UTC ODD Friday <br/>
+  * August 27, 2020, 1pm UTC ODD Thursday <br/>
+  * July 31, 2020, 1pm UTC ODD Friday <br/>
+  * June 25, 2020, 1pm UTC ODD Thursday <br/>
+  * May 25, 2020: during MEC Boston <br/>
+  * March 27, 2020, 1pm UTC <br/>
+  * January 31, 2020, 1pm UTC <br/>
+</details>
+
+<details>
+  <summary>ODD meetings in 2019</summary>
+
+  * November 29, 2019, 1pm UTC
+</details>


### PR DESCRIPTION
This PR moves the info about ODD meetings from the (deprecated) Wiki to the Technical Team page. 

It also fixes a minor layout issue on the TT page.

Fixes #338 

