### PR TITLE
fix(posts): fix broken link to MEI basic branch

### DIFF
--- a/_posts/2019-05-31-mei-basic-first-draft.md
+++ b/_posts/2019-05-31-mei-basic-first-draft.md
@@ -20,7 +20,7 @@ There are still aspects that need discussion, including the question of how
 much metadata should be allowed or required by MEI Basic.
 
 The development of MEI Basic happens at a separate branch of the MEI repository 
-at [https://github.com/music-encoding/music-encoding/tree/basic](https://github.com/music-encoding/music-encoding/tree/basic){:target="\_blank"}. 
+at [https://github.com/music-encoding/music-encoding/tree/basic](https://github.com/music-encoding/music-encoding/commit/b50748ce537b43e1527791fb41e8c28aa1582cdb){:target="\_blank"}. 
 
 Everyone from the MEI Community and beyond is invited to have a look at the 
 [current state of the customization](/downloads/mei-basic_2019-05-31_184d45b.xml){:target="\_blank"},


### PR DESCRIPTION
This PR fixes the broken link to the MEI basic branch reported by the link checker (in post "First Draft of MEI Basic", May 31, 2019). The branch was merged to `develop` in 2020 already, but the branch itself was deleted only 20 days ago ( music-encoding/music-encoding#584). That is why the link checker only now throws an error, since the branch is not available anymore for reference. 

With this PR, the post now links to the latest commit of the basic branch that was available at the time of the post.

Addresses one part of #335 