### PR TITLE
Update posts

### DIFF
--- a/_posts/2022-03-03-mec2022-registration.md
+++ b/_posts/2022-03-03-mec2022-registration.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  "Registration open for MEC 2022"
+date:   2022-03-03 12:00:00
+categories: update
+---
+I'm pleased to announce that registration for the Music Encoding Conference '22 is now open via the conference ConfTool page:
+
+[https://www.conftool.net/music-encoding2022/index.php?page=participate](https://www.conftool.net/music-encoding2022/index.php?page=participate)
+
+Please make use of the reduced-fee early registration rates (up to March 20, 2022) if possible. Your early registration will help us enormously with planning this complex hybrid conference!
+
+The conference webpage has been updated with a wealth of information about MEC '22. Please have a look:
+
+[https://music-encoding.org/conference/2022/](https://music-encoding.org/conference/2022/)
+
+BURSARIES FOR STUDENT PRESENTERS of approximately $800 CAD per successful applicant are available. Please see the following page for information on the simple application process, and note the urgent deadline of March 10, 2022!
+
+[https://music-encoding.org/conference/2022/bursaries/](https://music-encoding.org/conference/2022/bursaries/)
+
+CHILDCARE BURSARIES of $50 CAD per day (up to a maximum of $200 CAD per person) are also available. Please see the following page, noting the same urgent deadline!
+
+[https://music-encoding.org/conference/2022/childcare/](https://music-encoding.org/conference/2022/childcare/)
+
+We hope to see many of you (in-person at Dalhousie University, or virtually) at the Music Encoding Conference '22!
+
+On behalf of the conference organizers,
+David M. Weigl

--- a/_posts/2022-05-19-mec2021-proceedings-published.md
+++ b/_posts/2022-05-19-mec2021-proceedings-published.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  "MEC Proceedings 2021 published"
+date:   2022-05-19 12:00:00
+categories: update
+---
+
+It is our great pleasure to announce the upload of the MEC 2021 Proceedings to Humanities Commons: [https://doi.org/10.17613/fc1c-mx52](https://doi.org/10.17613/fc1c-mx52).
+
+You find an overview of all published items, including individual contributions, bibtex metadata and abstracts, here: [https://music-encoding.org/conference/proceedings.html](https://music-encoding.org/conference/proceedings.html).
+
+A huge collective effort and teamwork made it possible to get this volume with 24 contributions, 57 distinct authors and with a magical 222 (+2) pages ready for publication, just in time before MEC 2022. Many thanks to everyone involved!
+
+
+We wish you an exciting read,
+David Rizo and Stefan Münnich

--- a/_posts/2022-06-06-MEI-Developer-Workshop.md
+++ b/_posts/2022-06-06-MEI-Developer-Workshop.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  "MEI Developer Workshop"
+date:   2022-06-06 12:00:01
+categories: update
+---
+We’re happy to announce that Enote in Berlin (Germany) will host the next MEI Developer Meeting (local organization: Klaus Rettinghaus). 
+
+The meeting is scheduled for October 1–3, 2022, and, at least at this point, we assume that it can be held as an in-person event.
+
+The main objective of this working meeting is to discuss and work on various topics and ideas related to the technical development of MEI.
+
+For more information about the venue, accomodations, and a link to the registration form, please see the announcements on Slack or MEI-L.
+
+Looking forward to meeting you in Berlin,
+Klaus Rettinghaus, Benjamin W. Bohl & Stefan Münnich

--- a/_posts/2022-06-06-teaching-music-history-session.md
+++ b/_posts/2022-06-06-teaching-music-history-session.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "Event: Music encoding related panel at Teaching Music History Conference 2022"
+date:   2022-06-06 12:00
+categories: update
+---
+
+The 2022 Teaching Music History Conference, organized by the Pedagogy Study Group of the American Musicological Society, will take place June 10-11 (Friday–Saturday) at the University of Missouri – Kansas City. You may view the program at [https://www.teachingmusichistory.com/2022/03/19/tmhc2022-schedule/](https://www.teachingmusichistory.com/2022/03/19/tmhc2022-schedule/), registration links and further information can be found here: [https://www.teachingmusichistory.com/events/tmhc2022/](https://www.teachingmusichistory.com/events/tmhc2022/). The conference will also be livestreamed for registrants who cannot attend in-person.
+
+There is a panel related to music encoding organized by members of the MEI community and Digital Pegadogy IG (Maristella Feustle, Anna Kijas, Jessica H. Grimmer, Timothy Duguid) on Saturday, June 11 (11:00 – 12:00): "The X[ML]-Files: Pedagogies to Interrogate and Expand Music History".
+


### PR DESCRIPTION
This PR adds some posts to the events page, catching up some recent announcements about MEC2022 registration (just for the record), MEC2021 proceedings, MEI Developer Workshop 2022, and the panel of the Digital Pedagogy IG at the Teaching Music History Conference.