### PR TITLE
fix(gh-actions): update version of markdown-link-check action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -50,7 +50,7 @@ jobs:
 
 
       - name: Run markdown link check
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.8
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         id: mlc
         with:
           config-file: .github/link-checker-config.json


### PR DESCRIPTION
This PR updates the markdown-link-check action to the latest stable version 1.0.13. 

There are some issues going on with false positives reported by the action since an update of upstream dependencies, see gaurav-nelson/github-action-markdown-link-check#127 (debugging ongoing)