### PR TITLE
fix(gh-actions): pin of markdown-link-check action + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'gh actions dependencies'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -50,7 +50,7 @@ jobs:
 
 
       - name: Run markdown link check
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         id: mlc
         with:
           config-file: .github/link-checker-config.json


### PR DESCRIPTION
This PR pins the versin of the markdown-link-checker to v1 (which uses an older pinned version of the underlying upstream markdown-link-checker [mlc] that should not throw false positives 🤞 ). It also adds a dependabot.yml to notify about available updates of the gh-actions dependencies.

