### PR TITLE
fix(build): add .jekyll-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .DS_Store
 .jekyll-metadata
+.jekyll-cache


### PR DESCRIPTION
This PR adds the automatically generated ,jekyll-cache folder to gitignore to prevent it from being commited.