### PR TITLE
fix(gh-action): run jekyll action only on main repo

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build_jekyll:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'music-encoding'
+
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR prevents the jekyll build action from running on forks which is not needed. 