### PR TITLE
fix(conferences): fix broken diversity link

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.4
-        with:
-          fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/_conferences/2022/bursariesChildcare.html
+++ b/_conferences/2022/bursariesChildcare.html
@@ -18,7 +18,7 @@ id: childcare
     <li>title of presentation</li>
     <li>a 250-word statement of intent about how the conference participation meets your professional / academic goals.</li>
   </ul>
-  <p>The Music Encoding Conference 2022 applies <a href="https://www.dal.ca/cultureofrespect/diversity-strategy.html">Dalhousie University’s commitment</a> "to fostering a collegial culture grounded in diversity and inclusiveness." We especially encourage applications for the student bursaries from "Indigenous persons, persons with a disability, racialized persons, women, persons of a minority sexual orientation and/or gender identity, and all candidates who would contribute to the diversity of our community." You may wish to self-identify in your statement of intent.</p>
+  <p>The Music Encoding Conference 2022 applies <a href="https://www.dal.ca/dept/vpei/edia/diversity-inclusion-strategy.html">Dalhousie University’s commitment</a> "to fostering a collegial culture grounded in diversity and inclusiveness." We especially encourage applications for the student bursaries from "Indigenous persons, persons with a disability, racialized persons, women, persons of a minority sexual orientation and/or gender identity, and all candidates who would contribute to the diversity of our community." You may wish to self-identify in your statement of intent.</p>
   <p style="margin-top:2em;"><img src="/images/conference/2022/sshrc-fip-full-color-eng.png" width="100%" alt="SSHRC Logo" />
   <span style="position:relative; left:55px; top:-40px;">The Music Encoding Conference is supported in part by funding from the Social Sciences and Humanities Research Council of Canada.</span></p>
 

--- a/_conferences/2022/bursariesStudent.html
+++ b/_conferences/2022/bursariesStudent.html
@@ -20,7 +20,7 @@ id: bursaries
     <li>the name and contact information for your research supervisor, and</li>
     <li>a 250-word statement of intent about how the conference participation meets your professional / academic goals.</li>
   </ul>
-  <p>The Music Encoding Conference 2022 applies <a href="https://www.dal.ca/cultureofrespect/diversity-strategy.html">Dalhousie University’s commitment</a> "to fostering a collegial culture grounded in diversity and inclusiveness." We especially encourage applications for the student bursaries from "Indigenous persons, persons with a disability, racialized persons, women, persons of a minority sexual orientation and/or gender identity, and all candidates who would contribute to the diversity of our community." You may wish to self-identify in your statement of intent.</p>
+  <p>The Music Encoding Conference 2022 applies <a href="https://www.dal.ca/dept/vpei/edia/diversity-inclusion-strategy.html">Dalhousie University’s commitment</a> "to fostering a collegial culture grounded in diversity and inclusiveness." We especially encourage applications for the student bursaries from "Indigenous persons, persons with a disability, racialized persons, women, persons of a minority sexual orientation and/or gender identity, and all candidates who would contribute to the diversity of our community." You may wish to self-identify in your statement of intent.</p>
   <p style="margin-top:2em;"><img src="/images/conference/2022/sshrc-fip-full-color-eng.png" width="100%" alt="SSHRC Logo" />
   <span style="position:relative; left:55px; top:-40px;">The Music Encoding Conference is supported in part by funding from the Social Sciences and Humanities Research Council of Canada.</span></p>
 


### PR DESCRIPTION
This PR fixes the latest broken link to Dalhousie's diversity policy in the MEC2022 pages.

It also removes the "fail fast" option from the link checker because that option prevented the creation of issues.