### PR TITLE
fix(ci): fix verbosity level

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -10,7 +10,8 @@
 #############################  Display  #############################
 
 # Verbose program output
-verbose = true
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
 
 #############################  Runtime  #############################
 


### PR DESCRIPTION
Some days ago, lychee changed its implementation of the verbosity option. It does not accept boolean values any more, but expects one of the accepted log levels: "error", "warn", "info", "debug", or "trace".

Fixes #440 