### PR TITLE
feat(tutorials): add a back button for the tutorial steps

### DIFF
--- a/_layouts/tutorials-ES.html
+++ b/_layouts/tutorials-ES.html
@@ -42,8 +42,7 @@ layout: default
                     <!-- verovio rendering goes in here -->
                 </div>
             </div>
-            <button id="nextStepButton" class="btn btn-primary btn-sm float-right">Continúa <i class="icon icon-forward"></i></button>
-            
+         
             <div id="acknowledgments" style="display: none;">
                 <h3>Agradecimientos</h3>
                 <p>Este tutorial ha sido creado por:</p>
@@ -51,6 +50,11 @@ layout: default
                 <p>y traducido en la Universida de Alicante por Alba Bedbar y David Rizo</p>
             </div>
             
+            <div id="navigationButtons" style="width: 100%;">
+                <button id="previousStepButton" style="display: none;" class="btn btn-primary btn-sm float-left" ><i class="icon icon-back"></i> Atrás</button>
+                <button id="nextStepButton" style="display: none;" class="btn btn-primary btn-sm float-right">Continúa <i class="icon icon-forward"></i></button>
+            </div>  
+  
             <ul id="stepBox" class="step">
                 <!-- tutorial step list goes in here -->
             </ul>

--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -42,14 +42,18 @@ layout: default
                     <!-- verovio rendering goes in here -->
                 </div>
             </div>
-            <button id="nextStepButton" class="btn btn-primary btn-sm float-right">Continue <i class="icon icon-forward"></i></button>
-            
+                        
             <div id="acknowledgments" style="display: none;">
                 <h3>Acknowledgments</h3>
                 <p>This tutorial was brought to you by:</p>
                 <ul id="ackList"></ul>
             </div>
-            
+
+            <div id="navigationButtons" style="width: 100%;">
+                <button id="previousStepButton" style="display: none;" class="btn btn-primary btn-sm float-left" ><i class="icon icon-back"></i> Back</button>
+                <button id="nextStepButton" style="display: none;" class="btn btn-primary btn-sm float-right">Continue <i class="icon icon-forward"></i></button>
+            </div>  
+  
             <ul id="stepBox" class="step">
                 <!-- tutorial step list goes in here -->
             </ul>


### PR DESCRIPTION
This PR adds functionality for a back button to the tutorials. It mutes the button if there is no previous step. It also prevents both buttons from being displayed before the tutorial step gets loaded. 
The PR therefore reorganizes and restructures a bit of the logic of the tutorials' JS file. 

Fixes #464 

Screenshots:

![Screenshot 2023-05-07 235617](https://user-images.githubusercontent.com/21059419/236704402-2dae3651-7762-41a6-8e89-136ddbacc7a0.jpg)


![Screenshot 2023-05-07 235457](https://user-images.githubusercontent.com/21059419/236704366-66bf27b9-7ef8-4dce-88b7-9d5c7a3577b0.jpg)
