### PR TITLE
ci(gh-actions): use pinned SHA-1 instead of version tag for 3rd party actions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,7 +20,7 @@ jobs:
           ${{ runner.os }}-gems-
 
     # Build Jekyll to the specified target branch
-    - uses: helaili/jekyll-action@v2
+    - uses: helaili/jekyll-action@c1527523361ec3ecc54b2371ddef44826e28c0f5 # ratchet:helaili/jekyll-action@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         target_branch: 'gh-pages'

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,18 +9,18 @@ jobs:
     if: github.repository_owner == 'music-encoding'
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    # Use GitHub Actions' cache to shorten build times and decrease load on servers
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
-    # Build Jekyll to the specified target branch
-    - uses: helaili/jekyll-action@c1527523361ec3ecc54b2371ddef44826e28c0f5 # ratchet:helaili/jekyll-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        target_branch: 'gh-pages'
+      # Build Jekyll to the specified target branch
+      - uses: helaili/jekyll-action@c1527523361ec3ecc54b2371ddef44826e28c0f5 # ratchet:helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch: 'gh-pages'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.repository_owner == 'music-encoding' }}
 
     steps:
-      - uses: technote-space/broken-link-checker-action@v2
+      - uses: technote-space/broken-link-checker-action@7820497a025fb09ff736ee11bb8bb12ca715b4fe # ratchet:technote-space/broken-link-checker-action@v2
         with:
           target: ${{ env.CHECK_WEBSITE }}
 
@@ -45,13 +45,13 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.7.0
+        uses: lycheeverse/lychee-action@97189f2c0a3c8b0cb0e704fd4e878af6e5e2b2c5 # ratchet:lycheeverse/lychee-action@v1.7.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # ratchet:peter-evans/create-issue-from-file@v4
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md


### PR DESCRIPTION
This PR replaces version tags with their SHA-1 representation for all 3rd party actions used in the GH actions workflows. Github's own actions (starting with `action/...`) are not transformed.

For pinning the SHA-1, I used ratchet: https://github.com/sethvargo/ratchet . The tool can be run from CLI, CI or docker and provides easy methods to check for, pin or unpin tags and SHA-1's in a workflow.

Fixes #467 