### PR TITLE
fix(lychee): use a wildcard for 2022 conftool page

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -40,7 +40,7 @@ exclude = [
     'file:///Users/*',
 
     # former Conftool pages
-    'https://www.conftool.net/music-encoding2022/index.php?page=participate',
+    'https://www.conftool.net/music-encoding2022/*',
 
     # these DOIs are not correctly resolved (probably too many redirects)
     'https://doi.org/10.13140/RG.2.2.15014.93760',


### PR DESCRIPTION
This PR adjusts the exclusion of the no longer existing MEC '22 conftool page in the lychee config file. Instead of using the full path of the broken link, it uses a wildcard. At least locally, this throws no error anymore.

Fixes #477 
Fixes #475 
Fixes #474 