### PR TITLE
Add link to PDF

### DIFF
--- a/resources/schemas.md
+++ b/resources/schemas.md
@@ -8,6 +8,8 @@ The MEI Namespace is `http://www.music-encoding.org/ns/mei`
 
 # MEI v5.0 Schemas (2023)
 
+A PDF version of the MEI 5.0 Guidelines is available here: [https://music-encoding.org/guidelines/v5/MEI_Guidelines_v5.0.pdf](https://music-encoding.org/guidelines/v5/MEI_Guidelines_v5.0.pdf)
+
 New customization: MEI Basic. It provides a simplified subset of the MEI framework that reflects the capabilities of most popular "Common Western Music Notation" score-writing applications currently in use. For more details on MEI Basic [see the corresponding section ion the guidelines](https://music-encoding.org/guidelines/v5/content/introduction.html#meiBasic).
 
 - MEI Basic: [https://music-encoding.org/schema/5.0/mei-basic.rng](https://music-encoding.org/schema/5.0/mei-basic.rng)


### PR DESCRIPTION
This PR adds a link to the PDF to the MEI Namespace and Schemas page (PDFs from previous versions are available from there, too).