### PR TITLE
Add proceedings post

### DIFF
--- a/_posts/2023-09-01-mec2022-proceedings-published.md
+++ b/_posts/2023-09-01-mec2022-proceedings-published.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  "MEC Proceedings 2022 published"
+date:   2023-09-01 12:00:00
+categories: update
+---
+
+We are pleased to announce the publication of the 2022 Music Encoding Conference Proceedings. All contributions submitted for inclusion are now available with individual DOIs from the Music Encoding Initiative’s Humanities Commons group at https://hcommons.org/groups/music-encoding-initiative/deposits/. The full volume is available via https://doi.org/10.17613/sn48-8932.
+
+We thank you for your patience and hope you agree that the wait was worthwhile, as the Proceedings showcase the impressive variety of scholarship undertaken by our extended community.
+
+Video recordings of the excellent keynote presentations by Gimena del Rio Riande and Ichiro Fujinaga will be made available in the near future.
+
+With deep gratitude for your wonderful contributions at MEC ’22 in Halifax, and great excitement at the prospect of TEI-MEC 2023 in Paderborn next week,
+
+Ailynn Ang, Jennifer Bain, and David M. Weigl (Editors)


### PR DESCRIPTION
This PR adds a news post about the MEC2022 proceedings (dated back to the day of annoucement).