### PR TITLE
Add roundtable post

### DIFF
--- a/_posts/2023-10-06-ig-pedagogy-roundtable-published.md
+++ b/_posts/2023-10-06-ig-pedagogy-roundtable-published.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title:  "Publication: Digital Pedagogy IG Roundtable"
+date:   2023-10-06 12:00:00
+categories: update
+---
+
+The roundtable "Pedagogical Approaches to Music Encoding" of the Digital Pedagogy IG has been published in Journal of Musicological Research! Read at [https://doi.org/10.1080/01411896.2023.2231837](https://doi.org/10.1080/01411896.2023.2231837).
+
+Congrats to the contributors: Anna Kijas, Joy Calico, Jake Schaub, Anna Plaksin, Jessica Grimmer, Javier F. Merchán Sánchez-Jara, & Sara González Gutiérrez! 


### PR DESCRIPTION
This PR adds a news post about the roundtable publication of members of the Digital Pedagogy IG.