### PR TITLE
Update call.html (II)

### DIFF
--- a/_conferences/2024/call.html
+++ b/_conferences/2024/call.html
@@ -11,13 +11,13 @@ id: call
     
     <h2>Call for proposals</h2>
 
-    <p>We are pleased to announce our call for papers, posters, panels, and workshops for the Music Encoding Conference 2024. The conference will be held 20-23 May 2024 at the <a href="http://www.unt.edu/" target="_blank">University of North Texas</a> in Denton.</p>
+    <p>We are pleased to announce our call for papers, posters, panels, and workshops for the Music Encoding Conference 2024. The conference will be held 20-23 May 2024 at the <a href="http://www.unt.edu/" target="_blank" rel="noopener noreferrer">University of North Texas</a> in Denton.</p>
 
     <p>As an important cross-disciplinary venue for all who are interested in the digital representation of music, the Music Encoding Conference brings together members from various encoding, analysis, and music research communities, including musicologists, theorists, librarians, technologists, music scholars, teachers, and students, providing  an opportunity for all participants to learn from and engage with each other.</p>
 
 	<p>The deadline for all submissions is <strong>15 January 2024.</strong></p>
 
-	<p>To submit a proposal, please visit: [https://www.conftool.net/mec2024/](https://www.conftool.net/mec2024/)</p>
+	<p>To submit a proposal, please visit: <a href="https://www.conftool.net/mec2024/" target="_blank" rel="noopener noreferrer">https://www.conftool.net/mec2024/</a></p>
 
    
 


### PR DESCRIPTION
This PR fixes the markdown syntax for the conftool link inside the html file for the CfP introduced in #539 

It also secures the target blank links a bit.