### PR TITLE
Update lychee.toml

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -25,7 +25,7 @@ accept = [200, 429]
 
 # Remap URI matching pattern to different URI.
 remap = [
-    'file:///home/runner/work/music-encoding.github.io/music-encoding.github.io/_tutorials https://github.com/music-encoding/music-encoding.github.io/tree/gh-pages/tutorials/',
+    'file:///home/runner/work/music-encoding.github.io/music-encoding.github.io/_tutorials https://github.com/music-encoding/music-encoding.github.io/tree/gh-pages/tutorials',
     'https://github.com/music-encoding/music-encoding/tree/basic https://github.com/music-encoding/music-encoding/commit/b50748ce537b43e1527791fb41e8c28aa1582cdb',
     'http://music-encoding.org/community/conference/tours17/program/ https://web.archive.org/web/20170511140944/http://music-encoding.org/community/conference/tours17/program',
     'http://music-encoding.org/community/mei-organization/mei-by-laws/ https://music-encoding.org/community/mei-by-laws.html',


### PR DESCRIPTION
This PR removes the final slash from a lychee remap to the tutorials to fix the failing url path.