### PR TITLE
fix: exclude xitter from broken link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - uses: technote-space/broken-link-checker-action@b8332d945b97f8b52eb8d7d889a1e0e37106c1a9 # ratchet:technote-space/broken-link-checker-action@v2
         with:
-          target: ${{ env.CHECK_WEBSITE }}
+          TARGET: ${{ env.CHECK_WEBSITE }}
+          EXCLUDED_KEYWORDS: |
+            twitter.com
 
   linkChecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In #575, Xitter was excluded from the lycheeverse action. However, issues like #577 were raised from broken link checker action. This PR adds the exclusion keywords in that action.

Fixes #577