### PR TITLE
add conditional for external URLs

### DIFF
--- a/conference/past.md
+++ b/conference/past.md
@@ -27,7 +27,8 @@ title: "Past Music Encoding Conferences"
                   src="{% if conference.image contains '://' %}
                   {{ conference.image }}
                   {% else %}
-                  {{ site.baseurl }}/images/{{ conference.image }}"/>
+                  {{ site.baseurl }}/images/{{ conference.image }}
+                  {%  endif %}"/>
               {% else %}
                 <div class="hero hero-sm bg-primary text-light">
                   <div class="hero-body">

--- a/conference/past.md
+++ b/conference/past.md
@@ -23,7 +23,11 @@ title: "Past Music Encoding Conferences"
           <div class="card project">
             <div class="card-image">
               {% if conference.image %}
-                <img class="mei-project-image img-fit-cover" alt="{{ conference.tag }}" src="{{ site.baseurl }}/images/{{ conference.image }}"/>
+                <img class="mei-project-image img-fit-cover" alt="{{ conference.tag }}" 
+                  src="{% if conference.image contains '://' %}
+                  {{ conference.image }}
+                  {% else %}
+                  {{ site.baseurl }}/images/{{ conference.image }}"/>
               {% else %}
                 <div class="hero hero-sm bg-primary text-light">
                   <div class="hero-body">


### PR DESCRIPTION
For conference logos that refer to externally hosted images the current processing outputs malformed URLs like `https://music-encoding.org/images/https://teimec2023.uni-paderborn.de/assets/img/logo-full-encoding-cultures.png`.

This PR introduces a check for `://` that will bypass the default string operation to create the image link and simply output the URL as it is given in the conference yaml file.