### PR TITLE
conferences: minor layout patch

### DIFF
--- a/conference/past.md
+++ b/conference/past.md
@@ -32,7 +32,7 @@ title: "Past Music Encoding Conferences"
               {% else %}
                 <div class="hero hero-sm bg-primary text-light">
                   <div class="hero-body">
-                    <h1>{{ conference.tag }}</h1>
+                    <h3>{{ conference.tag }}</h3>
                   </div>
                 </div>
               {% endif %}

--- a/conference/past.md
+++ b/conference/past.md
@@ -25,10 +25,10 @@ title: "Past Music Encoding Conferences"
               {% if conference.image %}
                 <img class="mei-project-image img-fit-cover" alt="{{ conference.tag }}" 
                   src="{% if conference.image contains '://' %}
-                  {{ conference.image }}
-                  {% else %}
-                  {{ site.baseurl }}/images/{{ conference.image }}
-                  {%  endif %}"/>
+                        {{ conference.image }}
+                      {% else %}
+                        {{ site.baseurl }}/images/{{ conference.image }}
+                      {%  endif %}"/>
               {% else %}
                 <div class="hero hero-sm bg-primary text-light">
                   <div class="hero-body">


### PR DESCRIPTION
This PR reduces the size of the placeholder headers on the past conferences page (from h1 to h3, since they should not have the same size as the page title.)

Also, indents the fluid commands of the recently added image conditional.