### PR TITLE
tutorials: fix incipit tutorial

### DIFF
--- a/_tutorials-ES/102_incipit/102_incipit.json
+++ b/_tutorials-ES/102_incipit/102_incipit.json
@@ -481,16 +481,16 @@
         {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:note\/mei:artic\/@artic = 'acc'", "renderanyway": false, "hint": "Compás n=3: necesitas un atributo @artic con un valor acc en el elemento artic."},
         {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:note\/mei:artic\/@place = 'above'", "renderanyway": false, "hint": "Compás n=3: necesitas un atributo @place con un valor above en el elemento artic."},
         {"rule": "count(\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[1]\/@*) = 4", "renderanyway": false, "hint": "Necesitas cuatro atributos en la primera nota barrada (@pname, @oct, @dur & @xml:id) del primer elemento beam."},
-        {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[1]\/@*[name()='xml:id'] = 'd1e4614'", "renderanyway": false, "hint": "Necesitas a @xml:id attribute con un valor `d1e4614` en la primera nota barrada del primer elemento beam."},
+        {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[1]\/@*[name()='xml:id'] = 'd4567'", "renderanyway": false, "hint": "Necesitas a @xml:id attribute con un valor `d4567` en la primera nota barrada del primer elemento beam."},
         {"rule": "count(\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[2]\/@*) = 4", "renderanyway": false, "hint": "Necesitas cuatro atributos en la segunda nota barrada (@pname, @oct, @dur & @xml:id) del primer elemento beam."},
-        {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[2]\/@*[name()='xml:id'] = 'd1e4615'", "renderanyway": false, "hint": "Necesitas a @xml:id attribute con un valor `d1e4615` en la segunda nota barrada del primer elemento beam."},
+        {"rule": "\/\/mei:measure[4]\/mei:staff\/mei:layer\/mei:beam[1]\/mei:note[2]\/@*[name()='xml:id'] = 'd4568'", "renderanyway": false, "hint": "Necesitas a @xml:id attribute con un valor `d4568` en la segunda nota barrada del primer elemento beam."},
         {"rule": "count(\/\/mei:measure[4]\/mei:slur) = '1'", "renderanyway": false, "hint": "Necesitas un elemento slur como hijo de measure."},
         {"rule": "\/\/mei:measure[4]\/mei:staff\/following-sibling::mei:slur", "renderanyway": false, "hint": "el elemento slur tiene que seguir el elemento staff."},
         {"rule": "count(\/\/mei:measure[4]\/mei:slur\/@*) = 4", "renderanyway": false, "hint": "Necesitas cuatro atributos en el elemento slur (@staff, @curvedir, @startid & @endid)."},
         {"rule": "\/\/mei:measure[4]\/mei:slur\/@staff = '1'", "renderanyway": false, "hint": "Necesitas a @staff attribute con un valor 1 en slur."},
         {"rule": "\/\/mei:measure[4]\/mei:slur\/@curvedir = 'above'", "renderanyway": false, "hint": "Necesitas a @curvedir attribute con un valor above en slur."},
-        {"rule": "\/\/mei:measure[4]\/mei:slur\/@startid = '#d1e4614'", "renderanyway": false, "hint": "Necesitas a @startid attribute con un valor #d1e4614 en slur."},
-        {"rule": "\/\/mei:measure[4]\/mei:slur\/@endid = '#d1e4615'", "renderanyway": false, "hint": "Necesitas an @endid attribute con un valor #d1e4615 en slur."}
+        {"rule": "\/\/mei:measure[4]\/mei:slur\/@startid = '#d4567'", "renderanyway": false, "hint": "Necesitas a @startid attribute con un valor #d4567 en slur."},
+        {"rule": "\/\/mei:measure[4]\/mei:slur\/@endid = '#d4568'", "renderanyway": false, "hint": "Necesitas an @endid attribute con un valor #d4568 en slur."}
       ]
     }
   ],

--- a/_tutorials-ES/102_incipit/102_incipit.md
+++ b/_tutorials-ES/102_incipit/102_incipit.md
@@ -2,7 +2,7 @@
 layout: tutorials-ES
 type: tutorial-ES
 name: "AVANZADO: Codificación de íncipit"
-fullname: "Un tutorial avanzado sobre cómo codificar íncipits en MEII"
+fullname: "Un tutorial avanzado sobre cómo codificar íncipits en MEI"
 data: "102_incipit.json"
 ---
 ¡Bienvenido/a! En este tutorial aprenderás cómo codificar un íncipit (secuencia inicial de notas en una composición musical) en MEI con el siguiente ejemplo:

--- a/_tutorials-ES/102_incipit/step-04/102_incipit_step-04-desc.html
+++ b/_tutorials-ES/102_incipit/step-04/102_incipit_step-04-desc.html
@@ -9,7 +9,7 @@
         <li><code>@dur</code> (duración) - por ejemplo, <code>"1"</code> para la redonda, <code>"2"</code> para la blanca, <code>"4"</code> para la negra, <code>"8"</code> para la corchea, <code>"16"</code> para la semicorchea, ... <code>"2048"</code> para la 2048ª nota, utiliza <code>"4"</code>.</li>
     </ul>
 
-    <p>Aquí hay un ejemplo de cómo codificar una redonda C4: <code>&lt;nota pname="c" oct="4" dur="1"&gt;&lt;/nota&gt;</code>.</p>
+    <p>Aquí hay un ejemplo de cómo codificar una redonda C4: <code>&lt;note pname="c" oct="4" dur="1"/&gt;</code>.</p>
 
     <p class="tutorialTask">En el editor de abajo, introduce la codificación de la primera nota del ejemplo dentro del elemento <code>&lt;layer&gt;</code>.</p>
 

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -7,7 +7,7 @@
         <li>Un elemento separado <code>&lt;slur&gt;</code>.</li>
     </ol>
 
-    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> (lidaduras) son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
+    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> (ligaduras) son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
         Para permitir un control preciso sobre la ubicación de la ligadura en relación al pentagrama, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
 
     <p>Para indicar el punto inicial y el punto final de la ligadura,  se pueden usar los atributos <code>@startid</code> y <code>@endid</code>. 

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -37,6 +37,6 @@
     </ul>
 
     <p class="tutorialTask">Identifica la primera y la última nota a la que se une la ligadura (dentro del primer elemento <code>&lt;beam&gt;</code> del compás 3) y añade <code>@xml:id</code>s a ambos elementos <code>&lt;note&gt;</code>. 
-        Estos deben ser valores únicos para cada <code>@xml:id</code>, por lo que para este ejemplo usamos los valores: <code>"d4567"</code> para el <code>xml:id</code> de la nota inicial y <code>"d4568"</code> para el <code>xml:id</code> de la nota final del ligado. 
+        Estos deben ser valores únicos para cada <code>@xml:id</code>, por lo que para este ejemplo usamos los valores: <code>"d4567"</code> para el <code>xml:id</code> de la nota inicial y <code>"d4568"</code> para el <code>xml:id</code> de la nota final. 
         Añade un elemento de control <code>&lt;slur&gt;</code> después de la etiqueta de cierre del elemento <code>&lt;staff&gt;</code> y aplica los atributos correspondientes.</p>
 </div>

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -8,7 +8,7 @@
     </ol>
 
     <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> (lidaduras) son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
-        Para permitir un control preciso sobre la colocación del ligado en relación con el pentagrama musical, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
+        Para permitir un control preciso sobre la ubicación de la ligadura en relación al pentagrama, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
 
     <p>Para indicar el punto inicial y el punto final de la ligadura,  se pueden usar los atributos <code>@startid</code> y <code>@endid</code>. 
         Para hacerlo, los valores de los atributos <code>@startid</code> y <code>@endid</code> deben hacer referencia al valor del atributo <code>@xml:id</code> de los elementos donde comienza y termina la ligadura.

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -11,7 +11,7 @@
         Para permitir un control preciso sobre la colocación del ligado en relación con el pentagrama musical, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
 
     <p>Para indicar el punto inicial y el punto final de la ligadura,  se pueden usar los atributos <code>@startid</code> y <code>@endid</code>. 
-        Para hacerlo, los valores de los atributos <code>@startid</code> y <code>@endid</code> deben referenciar un atributo llamado <code>@xml:id</code> de los elementos reales donde comienza y termina el ligado.
+        Para hacerlo, los valores de los atributos <code>@startid</code> y <code>@endid</code> deben hacer referencia al valor del atributo <code>@xml:id</code> de los elementos donde comienza y termina la ligadura.
         Los <code>@xml:id</code> son identificadores con una secuencia de caracteres arbitraria pero única que regularizan la denominación de un elemento a lo largo de un documento
         y así facilitan la creación de enlaces entre elementos y otros recursos. Este es un mecanismo de referencia común en XML: aplicar un <code>@xml:id</code> a un elemento y referenciarlo desde otro elemento.</p>
 <p>En el caso de una ligadura <code>&lt;slur&gt;</code>, el atributo <code>@startid</code> hace referencia al <code>@xml:id</code> del elemento donde la ligadura inicia y el atributo <code>@endid</code> hace referencia al <code>@xml:id</code> del elemento donde la ligadura termina.</p>

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -7,7 +7,7 @@
         <li>Un elemento separado <code>&lt;slur&gt;</code>.</li>
     </ol>
 
-    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
+    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> (lidaduras) son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
         Para permitir un control preciso sobre la colocación del ligado en relación con el pentagrama musical, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
 
     <p>Para indicar el punto inicial y el punto final de la ligadura,  se pueden usar los atributos <code>@startid</code> y <code>@endid</code>. 

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -14,7 +14,7 @@
         Para hacerlo, los valores de los atributos <code>@startid</code> y <code>@endid</code> deben referenciar un atributo llamado <code>@xml:id</code> de los elementos reales donde comienza y termina el ligado.
         Los <code>@xml:id</code> son identificadores con una secuencia de caracteres arbitraria pero única que regularizan la denominación de un elemento a lo largo de un documento
         y así facilitan la creación de enlaces entre elementos y otros recursos. Este es un mecanismo de referencia común en XML: aplicar un <code>@xml:id</code> a un elemento y referenciarlo desde otro elemento.</p>
-    
+<p>En el caso de una ligadura <code>&lt;slur&gt;</code>, el atributo <code>@startid</code> hace referencia al <code>@xml:id</code> del elemento donde la ligadura inicia y el atributo <code>@endid</code> hace referencia al <code>@xml:id</code> del elemento donde la ligadura termina.</p>
     <p>Por ejemplo, si tienes un elemento <code>&lt;note&gt;</code> con un <code>@xml:id</code> de "note-1" y otro elemento <code>&lt;note&gt;</code> con un <code>@xml:id</code> de "note-2", 
         puedes crear un <code>&lt;slur&gt;</code> que comienza en la primera nota y termina en la segunda nota configurando el atributo <code>@startid</code> a "#note-1" y el atributo <code>@endid</code> a "#note-2". 
         Nota que el hash de referencia <code>#</code> solo se usa con los atributos de referencia, no con los <code>@xml:id</code> en sí mismos:</p>

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -26,7 +26,7 @@
         <code>&lt;slur staff="1" curvedir="above" startid="#note-1" endid="#note-2"/&gt;</code>
     </p>
 
-    <p>Debido a que los ligaduras pueden estar curvados en diferentes direcciones, el atributo <code>@curvedir</code> describe una curva con un término genérico que indica la dirección de la curvatura del ligado: <code>“above”</code>, <code>“below”</code> o <code>“mixed”</code>.</p>
+    <p>Debido a que las ligaduras pueden estar curvadas en diferentes direcciones, el atributo <code>@curvedir</code> describe una curva con un término genérico que indica la dirección de la curvatura de la ligadura: <code>“above”</code>, <code>“below”</code> o <code>“mixed”</code>.</p>
     
     <p>Así que los siguientes atributos deben usarse con el elemento <code>&lt;slur&gt;</code> en este paso:</p>
     <ul>

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -36,7 +36,7 @@
         <li><code>@curvedir</code> (dirección de la curva) - describe una curva con un término genérico que indica la dirección de la curvatura: <code>”above"</code>, <code>"below"</code> o <code>"mixed"</code>,</li>
     </ul>
 
-    <p class="tutorialTask">Identifica la primera y la última nota a la que se une la ligadura (dentro del primer elemento <code>&lt;beam&gt;</code> del compás 3) y añade <code>@xml:id</code>s a ambos elementos <code>&lt;note&gt;</code>. 
+    <p class="tutorialTask">Identifica la primera y la última nota que forman parte de la ligadura (dentro del primer elemento <code>&lt;beam&gt;</code> del compás 3) y añade <code>@xml:id</code>s a ambos elementos <code>&lt;note&gt;</code>. 
         Estos deben ser valores únicos para cada <code>@xml:id</code>, por lo que para este ejemplo usamos los valores: <code>"d4567"</code> para el <code>xml:id</code> de la nota inicial y <code>"d4568"</code> para el <code>xml:id</code> de la nota final. 
         Añade un elemento de control <code>&lt;slur&gt;</code> después de la etiqueta de cierre del elemento <code>&lt;staff&gt;</code> y aplica los atributos correspondientes.</p>
 </div>

--- a/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials-ES/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -7,17 +7,36 @@
         <li>Un elemento separado <code>&lt;slur&gt;</code>.</li>
     </ol>
 
-    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> son eventos de control. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.</p>
+    <p>En este último paso, se utilizará el segundo enfoque: Al igual que las dinámicas, los elementos <code>&lt;slur&gt;</code> son <i>eventos de control</i>. No se codifican como elementos hijos de los eventos correspondientes que deben controlar, sino que se colocan en la mayoría de los casos fuera de los elementos <code>staff</code>.
+        Para permitir un control preciso sobre la colocación del ligado en relación con el pentagrama musical, se puede usar el atributo <code>@staff</code>. Este atributo identifica el número del pentagrama al que se aplica el elemento <code>&lt;slur&gt;</code>.</p>
 
-    <p>Para indicar el punto inicial y el punto final de la ligadura, es posible aplicar una referencia al correspondiente <code>@xml:id</code> de un elemento <code>&lt;note&gt;</code> o <code>&lt;chord&gt;</code>. Los <code>@xml:id</code>s son identificadores con una secuencia de caracteres arbitraria pero única que regulariza la denominación de un elemento a lo largo de un documento y facilita así la construcción de enlaces entre elementos y otros recursos. En el caso de <code>&lt;slur&gt;</code>, la referencia al <code>@xml:id</code> de un elemento puede darse a través de los atributos <code>@startid</code> y <code>@endid</code>.</p>
+    <p>Para indicar el punto inicial y el punto final de la ligadura,  se pueden usar los atributos <code>@startid</code> y <code>@endid</code>. 
+        Para hacerlo, los valores de los atributos <code>@startid</code> y <code>@endid</code> deben referenciar un atributo llamado <code>@xml:id</code> de los elementos reales donde comienza y termina el ligado.
+        Los <code>@xml:id</code> son identificadores con una secuencia de caracteres arbitraria pero única que regularizan la denominación de un elemento a lo largo de un documento
+        y así facilitan la creación de enlaces entre elementos y otros recursos. Este es un mecanismo de referencia común en XML: aplicar un <code>@xml:id</code> a un elemento y referenciarlo desde otro elemento.</p>
+    
+    <p>Por ejemplo, si tienes un elemento <code>&lt;note&gt;</code> con un <code>@xml:id</code> de "note-1" y otro elemento <code>&lt;note&gt;</code> con un <code>@xml:id</code> de "note-2", 
+        puedes crear un <code>&lt;slur&gt;</code> que comienza en la primera nota y termina en la segunda nota configurando el atributo <code>@startid</code> a "#note-1" y el atributo <code>@endid</code> a "#note-2". 
+        Nota que el hash de referencia <code>#</code> solo se usa con los atributos de referencia, no con los <code>@xml:id</code> en sí mismos:</p>
+    
+    <p>
+        <code>&lt;note xml:id="note-1" pname="g" oct="4" dur="4"/&gt;</code><br>
+        <code>&lt;note xml:id="note-2" pname="a" oct="4" dur="4"/&gt;</code><br>
+        <code>...</code><br>
+        <code>&lt;slur staff="1" curvedir="above" startid="#note-1" endid="#note-2"/&gt;</code>
+    </p>
 
-    <p>Junto con <code>@startid</code> y <code>@endid</code>, se deben utilizar los siguientes atributos en este paso:</p>
+    <p>Debido a que los ligaduras pueden estar curvados en diferentes direcciones, el atributo <code>@curvedir</code> describe una curva con un término genérico que indica la dirección de la curvatura del ligado: <code>“above”</code>, <code>“below”</code> o <code>“mixed”</code>.</p>
+    
+    <p>Así que los siguientes atributos deben usarse con el elemento <code>&lt;slur&gt;</code> en este paso:</p>
     <ul>
         <li><code>@staff</code> - el número de identificación del pentagrama al que se aplica un elemento, por ejemplo, <code>"1"</code> en este caso,</li>
-        <li><code>@curvedir</code> (dirección de la curva) - describe una curva con un término genérico que indica la dirección de la curvatura: <code>”above"</code>, <code>"below"</code> o <code>"mixed"</code>,</li>
         <li><code>@startid</code> - referencia al <code>xml:id</code> de la nota de inicio de la ligadura, de la forma: <code>#xml:id</code> (nótese el signo <code>#</code>),</li>
         <li><code>@endid</code> - referencia al <code>xml:id</code> de la nota final de la ligadura, de la forma: <code>#xml:id</code> (nótese el signo <code>#</code>).</li>
+        <li><code>@curvedir</code> (dirección de la curva) - describe una curva con un término genérico que indica la dirección de la curvatura: <code>”above"</code>, <code>"below"</code> o <code>"mixed"</code>,</li>
     </ul>
 
-    <p class="tutorialTask">Identifica la primera y la última nota a la que se une la ligadura (dentro del primer elemento <code>&lt;beam&gt;</code> del compás 3) y añade <code>@xml:id</code>s a ambos elementos <code>&lt;note&gt;</code>. Establece un valor único para cada <code>@xml:id</code>, para este ejemplo puedes utilizar los valores: <code>“d1e4614”</code>, <code>“d1e4615”</code>. Añade un elemento de control <code>&lt;slur&gt;</code> después de la etiqueta de cierre del elemento <code>&lt;staff&gt;</code> y aplica los atributos correspondientes.</p>
+    <p class="tutorialTask">Identifica la primera y la última nota a la que se une la ligadura (dentro del primer elemento <code>&lt;beam&gt;</code> del compás 3) y añade <code>@xml:id</code>s a ambos elementos <code>&lt;note&gt;</code>. 
+        Estos deben ser valores únicos para cada <code>@xml:id</code>, por lo que para este ejemplo usamos los valores: <code>"d4567"</code> para el <code>xml:id</code> de la nota inicial y <code>"d4568"</code> para el <code>xml:id</code> de la nota final del ligado. 
+        Añade un elemento de control <code>&lt;slur&gt;</code> después de la etiqueta de cierre del elemento <code>&lt;staff&gt;</code> y aplica los atributos correspondientes.</p>
 </div>

--- a/_tutorials/102_incipit/102_incipit.json
+++ b/_tutorials/102_incipit/102_incipit.json
@@ -481,16 +481,16 @@
         {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:note/mei:artic/@artic = 'acc'", "renderanyway": false, "hint": "Measure n=3: You need a @artic attribute with a value of acc on artic element."},
         {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:note/mei:artic/@place = 'above'", "renderanyway": false, "hint": "Measure n=3: You need an @place attribute with a value of above on the artic element."},
         {"rule": "count(//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[1]/@*) = 4", "renderanyway": false, "hint": "You need four attributes on the first beamed note (@pname, @oct, @dur & @xml:id) of the first beam."},
-        {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[1]/@*[name()='xml:id'] = 'd1e4614'", "renderanyway": false, "hint": "You need a @xml:id attribute with a value of `d1e4614` on the first beamed note of the first beam."},
+        {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[1]/@*[name()='xml:id'] = 'd4567'", "renderanyway": false, "hint": "You need a @xml:id attribute with a value of `d4567` on the first beamed note of the first beam."},
         {"rule": "count(//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[2]/@*) = 4", "renderanyway": false, "hint": "You need four attributes on the second beamed note (@pname, @oct, @dur & @xml:id) of the first beam."},
-        {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[2]/@*[name()='xml:id'] = 'd1e4615'", "renderanyway": false, "hint": "You need a @xml:id attribute with a value of `d1e4615` on the second beamed note of the first beam."},
+        {"rule": "//mei:measure[4]/mei:staff/mei:layer/mei:beam[1]/mei:note[2]/@*[name()='xml:id'] = 'd4568'", "renderanyway": false, "hint": "You need a @xml:id attribute with a value of `d4568` on the second beamed note of the first beam."},
         {"rule": "count(//mei:measure[4]/mei:slur) = '1'", "renderanyway": false, "hint": "You need a slur element as child of measure."},
         {"rule": "//mei:measure[4]/mei:staff/following-sibling::mei:slur", "renderanyway": false, "hint": "slur element has to follow the staff element."},
         {"rule": "count(//mei:measure[4]/mei:slur/@*) = 4", "renderanyway": false, "hint": "You need four attributes on the slur element (@staff, @curvedir, @startid & @endid)."},
         {"rule": "//mei:measure[4]/mei:slur/@staff = '1'", "renderanyway": false, "hint": "You need a @staff attribute with a value of 1 on slur."},
         {"rule": "//mei:measure[4]/mei:slur/@curvedir = 'above'", "renderanyway": false, "hint": "You need a @curvedir attribute with a value of above on slur."},
-        {"rule": "//mei:measure[4]/mei:slur/@startid = '#d1e4614'", "renderanyway": false, "hint": "You need a @startid attribute with a value of #d1e4614 on slur."},
-        {"rule": "//mei:measure[4]/mei:slur/@endid = '#d1e4615'", "renderanyway": false, "hint": "You need an @endid attribute with a value of #d1e4615 on slur."}
+        {"rule": "//mei:measure[4]/mei:slur/@startid = '#d4567'", "renderanyway": false, "hint": "You need a @startid attribute with a value of #d4567 on slur."},
+        {"rule": "//mei:measure[4]/mei:slur/@endid = '#d4568'", "renderanyway": false, "hint": "You need an @endid attribute with a value of #d4568 on slur."}
       ]
     }
   ],

--- a/_tutorials/102_incipit/step-04/102_incipit_step-04-desc.html
+++ b/_tutorials/102_incipit/step-04/102_incipit_step-04-desc.html
@@ -9,7 +9,7 @@
         <li><code>@dur</code> (duration) – e.g. <code>“1”</code> for whole note, <code>“2”</code> for half note, <code>“4”</code> for quarter note, <code>“8”</code> for eighth note, <code>“16”</code> for sixteenth note, … <code>“2048”</code> for 2048th note, use <code>“4”</code></li>
     </ul>
 
-    <p>Here is an example of how to encode a whole note C4: <code>&lt;note pname="c" oct="4" dur="1"&gt;&lt;/note&gt;</code>.</p>
+    <p>Here is an example of how to encode a whole note C4: <code>&lt;note pname="c" oct="4" dur="1"/&gt;</code>.</p>
 
     <p class="tutorialTask">In the editor below, please enter the encoding of the first note of the example inside the <code>&lt;layer&gt;</code> element.</p>
 

--- a/_tutorials/102_incipit/step-12/102_incipit_step-12-desc.html
+++ b/_tutorials/102_incipit/step-12/102_incipit_step-12-desc.html
@@ -8,20 +8,39 @@
         <li>A separate <code>&lt;slur&gt;</code> element.</li>
     </ol>
 
-    <p>In this last step, you will use the second approach: Like dynamics, <code>&lt;slur&gt;</code> elements are control events. They are not encoded as child elements of the corresponding events that they are meant to control but are placed in most cases outside the <code>staff</code> elements.</p>
+    <p>In this last step, you will use the second approach: Like dynamics, <code>&lt;slur&gt;</code> elements are <i>control events</i>. They are not encoded as child elements of the corresponding events that they are meant to control but are placed in most cases outside the <code>staff</code> elements. 
+        To still allow precise control over the placement of the slur in relation to the musical staff, the <code>@staff</code> attribute can be used. This attribute identifies the number of the staff to which the <code>&lt;slur&gt;</code> element is applied.</p>
 
-    <p>To indicate the starting point and end point of the slur, it is possible to apply a reference to the corresponding <code>@xml:id</code> of a <code>&lt;note&gt;</code> or
-    <code>&lt;chord&gt;</code> element. <code>@xml:id</code>s are identifiers with an arbitrary but unique character sequence that regularize the naming of an element throughout a document
-    and thus facilitate building links between elements and other resources. For <code>&lt;slur&gt;</code>s, a reference to the <code>@xml:id</code> of an element can be given via the
-    attributes <code>@startid</code> and <code>@endid</code>.</p>
+    <p>To indicate the starting point and end point of the slur, the <code>@startid</code> and <code>@endid</code> attributes can be used. 
+        To do so, the values of the <code>@startid</code> and <code>@endid</code> attributes need to reference an attribute called <code>@xml:id</code> of the actual elements where the slur starts and ends.
+        <code>@xml:id</code>s are identifiers with an arbitrary but unique character sequence that regularize the naming of an element throughout a document
+        and thus facilitate building links between elements and other resources. This is a common reference mechanism in XML: applying an <code>@xml:id</code> to one element, and referencing it from another element.</p>
 
-    <p>Along with <code>@startid</code> and <code>@endid</code>, the following attributes should be used in this step:</p>
+    <p>For <code>&lt;slur&gt;</code>s, the <code>@startid</code> attribute contains a reference to the <code>@xml:id</code> of the element where the slur begins, and the <code>@endid</code> attribute contains a reference to the <code>@xml:id</code> of the element where the slur ends.</p>
+        
+    <p>For example, if you have a <code>&lt;note&gt;</code> element with an <code>@xml:id</code> of "note-1" and another <code>&lt;note&gt;</code> element with an <code>@xml:id</code> of "note-2", 
+        you can create a <code>&lt;slur&gt;</code> that starts at the first note and ends at the second note by setting the <code>@startid</code> attribute to "#note-1" and the <code>@endid</code> attribute to "#note-2". 
+        Note that the reference hash <code>#</code> is only used with the referencing attributes, not with the <code>@xml:id</code>s itself:</p>
+
+    <p>
+        <code>&lt;note xml:id="note-1" pname="g" oct="4" dur="4"/&gt;</code><br>
+        <code>&lt;note xml:id="note-2" pname="a" oct="4" dur="4"/&gt;</code><br>
+        <code>...</code><br>
+        <code>&lt;slur staff="1" curvedir="above" startid="#note-1" endid="#note-2"/&gt;</code>
+    </p>
+
+    <p>Since slurs can be curved in different directions, the <code>@curvedir</code> attribute describes a curve with a generic term indicating the direction of curvature of the slur: <code>“above”</code>, <code>“below”</code> or <code>“mixed”</code>.</p>
+
+    
+    <p>So the following attributes should be used with the <code>&lt;slur&gt;</code> element in this step:</p>
     <ul>
         <li><code>@staff</code> – the identification number of the staff to which an element is applied, e.g. <code>“1”</code> in this case,</li>
-        <li><code>@curvedir</code> (curve direction) – describes a curve with a generic term indicating the direction of curvature: <code>“above”</code>, <code>“below”</code> or <code>“mixed”</code>,</li>
         <li><code>@startid</code> – reference to the <code>xml:id</code> of the start note of the slur, in the form: <code>#xml:id</code> (note the hash <code>#</code>),</li>
         <li><code>@endid</code> – reference to the <code>xml:id</code> of the ending note of the slur, in the form: <code>#xml:id</code> (note the hash <code>#</code>).</li>
+        <li><code>@curvedir</code> (curve direction) – describes a curve with a generic term indicating the direction of curvature of the slur: <code>“above”</code>, <code>“below”</code> or <code>“mixed”</code>,</li>
     </ul>
 
-    <p class="tutorialTask">Please identify the first and the last note to which the slur is attached (inside the first <code>&lt;beam&gt;</code> element of measure 3) and add <code>@xml:id</code>s to both <code>&lt;note&gt;</code> elements. Set a unique value for each <code>@xml:id</code>, for this example you can use the values: <code>“d1e4614”</code>, <code>“d1e4615”</code>. Add a <code>&lt;slur&gt;</code> control element after the closing tag of <code>&lt;staff&gt;</code> element and apply the corresponding attributes.</p>
+    <p class="tutorialTask">Please identify the first and the last note to which the slur is attached (inside the first <code>&lt;beam&gt;</code> element of measure 3) and add <code>@xml:id</code>s to both <code>&lt;note&gt;</code> elements.
+        These need to be unique values for each <code>@xml:id</code>, so for this example we use the values: <code>"d4567"</code> for the <code>xml:id</code> of the start note and <code>"d4568"</code> for the <code>xml:id</code> of the end note of the slur. 
+        Add a <code>&lt;slur&gt;</code> control element after the closing tag of <code>&lt;staff&gt;</code> element and apply the corresponding attributes.</p>
 </div>

--- a/_tutorials/102_incipit/step-12/102_incipit_step-12.xml
+++ b/_tutorials/102_incipit/step-12/102_incipit_step-12.xml
@@ -60,8 +60,8 @@
                             <staff n="1">
                                 <layer>
                                     <beam>
-                                        <note dur="8" pname="a" oct="4" xml:id="d1e4614"></note>
-                                        <note dur="8" pname="b" oct="4" xml:id="d1e4615"></note>
+                                        <note dur="8" pname="a" oct="4" xml:id="d4567"></note>
+                                        <note dur="8" pname="b" oct="4" xml:id="d4568"></note>
                                         <note dur="8" pname="c" oct="5"></note>
                                         <note dur="8" pname="d" oct="5"></note>
                                     </beam>
@@ -74,7 +74,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <slur staff="1" startid="#d1e4614" endid="#d1e4615" curvedir="above" />
+                            <slur staff="1" startid="#d4567" endid="#d4568" curvedir="above" />
                         </measure>
                         <?edit-end?>
                         <measure n="4">


### PR DESCRIPTION
This PR adds some improvements for the incipit tutorial, including those proposed in #263 by @mfeustle .

This includes : 
- simplifying the note example in step 4;
- simplifying and improving readability of the xml:ids used in the final step;
- improving the explanation of the attributes used in the final step;
- improving the explanation of the referencing mechanism with xml:ids in the final step;
- fixing a typo in the title of the incipit tutorial in the Spanish translation.

Fixes #263 