### PR TITLE
Updated name of repository

### DIFF
--- a/community/community-contacts.md
+++ b/community/community-contacts.md
@@ -23,9 +23,9 @@ To join, please follow [this link](https://join.slack.com/t/music-encoding/share
 
 Slack has [clients](https://slack.com/) for Mac, PC, Linux, and mobile devices, and may be used via any web browser.
 
-# Humanities Commons: MEI Group
+# Knowledge Commons: MEI Group
 
-The Music Encoding Initiative group in the Humanities Commons is devoted to a discussion of topics related to music encoding, and is an extension of the Music Encoding Initiative channels on MEI-L and website. The Humanities Commons is a network for people working in the humanities. Connect with other scholars and their scholarship, and increase the impact of your work by sharing it in the repository. The MEI Group at the Humanities Commons can be accessed at [https://hcommons.org/groups/music-encoding-initiative/](https://hcommons.org/groups/music-encoding-initiative/).
+The Music Encoding Initiative group in the Knowledge Commons (previously called Humanities Commons) is devoted to a discussion of topics related to music encoding, and is an extension of the Music Encoding Initiative channels on MEI-L and website. The Knowledge Commons is a network for people working in the humanities. Connect with other scholars and their scholarship, and increase the impact of your work by sharing it in the repository. The MEI Group at the Knowledge Commons can be accessed at [https://hcommons.org/groups/music-encoding-initiative/](https://hcommons.org/groups/music-encoding-initiative/).
 
 # Contact info
 

--- a/resources/pedagogy.md
+++ b/resources/pedagogy.md
@@ -8,11 +8,11 @@ A community knowledge-base encourages participation. MEI practitioners and instr
 
 Resources on this page may include, but are not limited to cheat sheets, lesson plans/outcomes, tutorials, media, templates, and other resources. Content written in any language may be submitted. Please be aware that the content will be presented as it was received from the contributors. It will not be peer-reviewed for accuracy or efficacy. 
 
-We will upload your resource(s) to the [Music Encoding Initiative Humanities Commons (HC) Repository](https://hcommons.org/groups/music-encoding-initiative/) along with descriptive metadata to ensure discoverability. Each resource will be assigned tags to enable filtering and easier searching. View resources under the tag: [MEI-Pedgagogy-Praxis](https://hcommons.org/deposits/?tag=mei-pedagogy-praxis). All contributions will be licensed under a Creative Commons Attribution-NonCommercial-ShareAlike ([CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/)) license.
+We will upload your resource(s) to the [Music Encoding Initiative Knowledge Commons Repository](https://hcommons.org/groups/music-encoding-initiative/) (previously called Humanities Commons) along with descriptive metadata to ensure discoverability. Each resource will be assigned tags to enable filtering and easier searching. View resources under the tag: [MEI-Pedgagogy-Praxis](https://hcommons.org/deposits/?tag=mei-pedagogy-praxis). All contributions will be licensed under a Creative Commons Attribution-NonCommercial-ShareAlike ([CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/)) license.
 
 If you would like to contribute a resource that you created or collaborated on, please [complete this form](https://docs.google.com/forms/d/e/1FAIpQLScnaXFQhtxVrt2aCaKqf0F4by_XgHHsvxhyq9-cvCDPE0j9vg/viewform) where you will need to provide descriptive metadata along with your content. Contributions can be submitted on a rolling basis and you will be notified once your content is added to the repository.
 
-If you have questions or need assistance, please reach out to the [Pedagogy Interest Group Administrative Co-Chairs](https://music-encoding.org/community/interest-groups.html), Anna Kijas and Jessica Grimmer.
+If you have questions or need assistance, please reach out to the [Pedagogy Interest Group Administrative Co-Chairs](https://music-encoding.org/community/interest-groups.html), Jessica Grimmer and Joshua Neumann.
 
 ## Recurring Events
 


### PR DESCRIPTION
Updated text to reflect new name. Humanities Commons is now Knowledge Commons.