### PR TITLE
Add 2024 Call for Nominations

### DIFF
--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Call for nominations 2024"
-date: 2024-10-25 16:00:00 +0000
+date: 2024-10-28 16:00:00 +0000
 categories: update
 ---
 
@@ -18,7 +18,7 @@ The timeline of the elections will be as follows:
 - Any individual is eligible for nomination, including those who have previously served on the MEI Board. Candidates in the election must be members of the MEI-L mailing list but may register until 26 November 2024.
 - Self-nominations are welcome.
 - Individuals will be informed of their nomination when received and asked to confirm their willingness to serve on the MEI Board.
-- Acceptance of a nomination requires submission of a short CV and a personal statement of interest in MEI (a maximum of 200 words each) to elections@music-encoding.org by 22 November 2024.
+- Acceptance of a nomination requires submission of a short CV and a personal statement of interest in MEI (a maximum of 200 words each) to elections@music-encoding.org by 26 November 2024.
 - Candidates who have been nominated but have not confirmed their willingness by 26 November 2024 will not be included on the ballot.
 
 **Election phase** (27 November – 15 December 2024)

--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: "Call for nominations 2024"
+date: 2024-10-25 16:00:00 +0000
+categories: update
+---
+
+On 31 December 2024, the terms of three MEI Board members will end. In the name of the entire MEI community, the MEI Board expresses its gratitude to Benjamin W. Bohl, Anna E. Kijas, and Klaus Rettinghaus for their service and dedication to MEI.
+
+In the 2024 MEI Board elections, the MEI community will determine three MEI Board members for the term 2025–2027. The election process will take place in accordance with the [Music Encoding Initiative By-Laws](http://music-encoding.org/community/mei-by-laws.html).
+
+The timeline of the elections will be as follows:
+
+**Nomination phase** (25 October – 8 November 2024; All deadlines are 11:59 pm, UTC)
+
+- You can submit nominations by filling in the form linked in the Call for Nominations posted to the MEI-L mailing list.
+- Any person who today is a subscriber of the MEI-L mailing list has the right to nominate candidates.
+- Any individual is eligible for nomination, including those who have previously served on the MEI Board. Candidates in the election must be members of the MEI-L mailing list but may register until 22 November 2024.
+- Self-nominations are welcome.
+- Individuals will be informed of their nomination when received and asked to confirm their willingness to serve on the MEI Board.
+- Acceptance of a nomination requires submission of a short CV and a personal statement of interest in MEI (a maximum of 200 words each) to elections@music-encoding.org by 22 November 2024.
+- Candidates who have been nominated but have not confirmed their willingness by 22 November 2024 will not be included on the ballot.
+
+**Election phase** (25 November – 12 December 2024)
+
+- The election will take place using OpaVote and the Scottish STV Ranked Choice Voting method (https://www.opavote.com/methods/single-transferable-vote#scottish-stv).
+- We will inform you in separate emails about the start of the election and your individual voting tokens.
+
+**Post-election phase**
+
+- Election results will be announced after the elections have closed.
+- The term of the elected candidates starts on 1 January 2025.
+- The first meeting of the new MEI Board will be held in January, 2025 (precise date tbc).
+
+The election of Board members is an opportunity for each of you to have a voice in determining the future of MEI.
+
+Thank you for your support,
+David M. Weigl and Peter Stadler
+MEI election administrators 2024
+by appointment of the MEI Board

--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -11,17 +11,17 @@ In the 2024 MEI Board elections, the MEI community will determine three MEI Boar
 
 The timeline of the elections will be as follows:
 
-**Nomination phase** (25 October – 8 November 2024; All deadlines are 11:59 pm, UTC)
+**Nomination phase** (28 October – 11 November 2024; All deadlines are 11:59 pm, UTC)
 
 - You can submit nominations by filling in the form linked in the Call for Nominations posted to the MEI-L mailing list.
 - Any person who today is a subscriber of the MEI-L mailing list has the right to nominate candidates.
-- Any individual is eligible for nomination, including those who have previously served on the MEI Board. Candidates in the election must be members of the MEI-L mailing list but may register until 22 November 2024.
+- Any individual is eligible for nomination, including those who have previously served on the MEI Board. Candidates in the election must be members of the MEI-L mailing list but may register until 26 November 2024.
 - Self-nominations are welcome.
 - Individuals will be informed of their nomination when received and asked to confirm their willingness to serve on the MEI Board.
 - Acceptance of a nomination requires submission of a short CV and a personal statement of interest in MEI (a maximum of 200 words each) to elections@music-encoding.org by 22 November 2024.
-- Candidates who have been nominated but have not confirmed their willingness by 22 November 2024 will not be included on the ballot.
+- Candidates who have been nominated but have not confirmed their willingness by 26 November 2024 will not be included on the ballot.
 
-**Election phase** (25 November – 12 December 2024)
+**Election phase** (27 November – 15 December 2024)
 
 - The election will take place using OpaVote and the Scottish STV Ranked Choice Voting method (https://www.opavote.com/methods/single-transferable-vote#scottish-stv).
 - We will inform you in separate emails about the start of the election and your individual voting tokens.

--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Call for nominations 2024"
-date: 2024-10-28 16:00:00 +0000
+date: 2024-10-28 10:00:00 +0000
 categories: update
 ---
 

--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Call for nominations 2024"
-date: 2024-10-28 10:00:00 +0000
+date: 2024-10-28 09:30:00 +0000
 categories: update
 ---
 

--- a/_posts/2024-10-25-call-for-nominations.md
+++ b/_posts/2024-10-25-call-for-nominations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Call for nominations 2024"
-date: 2024-10-28 09:30:00 +0000
+date: 2024-10-28 08:30:00 +0000
 categories: update
 ---
 


### PR DESCRIPTION
This PR adds the Call for Nominations for the 2024 MEI election to the news page
Currently a draft PR to prevent accidental merging until Oct 25, 2024 (start of nominations phase)