### PR TITLE
fix(proceedings): activate proceedings

### DIFF
--- a/conference/proceedings.md
+++ b/conference/proceedings.md
@@ -8,6 +8,14 @@ title: "Proceedings"
 <div class="columns">
     <div class="column col-12 mec-proceedings">
         <div class="mec-proceedings-section">
+            <div class="mec-proceedings-section-divider"><span>2024</span></div>
+            <div id="mec-proceedings-2024">
+                <div class="mec-proceedings-entries">
+                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-2024&group0=displayby"></script>
+                </div>
+            </div>
+        </div>        
+        <div class="mec-proceedings-section">
             <div class="mec-proceedings-section-divider"><span>2021</span></div>
             <div id="mec-proceedings-2021">
                 <div class="mec-proceedings-entries">

--- a/conference/proceedings.md
+++ b/conference/proceedings.md
@@ -7,45 +7,16 @@ title: "Proceedings"
 
 <div class="columns">
     <div class="column col-12 mec-proceedings">
-        <div class="mec-proceedings-section">
-            <div class="mec-proceedings-section-divider"><span>2024</span></div>
-            <div id="mec-proceedings-2024">
-                <div class="mec-proceedings-entries">
-                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-2024&group0=displayby"></script>
+        {% assign publicationPeriods = "2024,2021,2020,2015–2017,2013–2014" | split: "," %}
+        {% for period in publicationPeriods %}
+            <div class="mec-proceedings-section">
+                <div class="mec-proceedings-section-divider"><span>{{ period }}</span></div>
+                <div id="mec-proceedings-{{ period }}">
+                    <div class="mec-proceedings-entries">
+                        <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-{{ period | replace: '–', '%7C' }}&group0=displayby"></script>
+                    </div>
                 </div>
             </div>
-        </div>        
-        <div class="mec-proceedings-section">
-            <div class="mec-proceedings-section-divider"><span>2021</span></div>
-            <div id="mec-proceedings-2021">
-                <div class="mec-proceedings-entries">
-                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-2021&group0=displayby"></script>
-                </div>
-            </div>
-        </div>        
-        <div class="mec-proceedings-section">
-            <div class="mec-proceedings-section-divider"><span>2020</span></div>
-            <div id="mec-proceedings-2020">
-                <div class="mec-proceedings-entries">
-                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-2020&group0=displayby"></script>
-                </div>
-            </div>
-        </div>
-        <div class="mec-proceedings-section">
-            <div class="mec-proceedings-section-divider"><span>2015, 2016 &amp; 2017</span></div>
-             <div id="mec-proceedings-2015-2017">
-                <div class="mec-proceedings-entries">
-                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-(2015%7C2016%7C2017)&group0=displayby"></script>
-                </div>
-            </div>
-        </div>
-        <div class="mec-proceedings-section">
-            <div class="mec-proceedings-section-divider"><span>2013 &amp; 2014</span></div>
-            <div id="mec-proceedings-2013-2014">
-                <div class="mec-proceedings-entries">
-                    <script src="https://bibbase.org/show?bib=https%3A%2F%2Fraw.githubusercontent.com%2Fmusic-encoding%2Fmusic-encoding.github.io%2Fmain%2Fconference%2Fmec_proceedings.bib&jsonp=1&theme=simple&nocache=1&authorFirst=1&filter=keywords:mec-proceedings-(2013%7C2014)&group0=displayby"></script>
-                </div>
-            </div>
-        </div>
+        {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
This PR activates the 2024 proceedings which was forgotten in #707.

It also simplifies the logic for the proceedings html by looping over the publication periods instead of repeating the html for every period.