### PR TITLE
MEC 2025: Announce CfP deadline extension

### DIFF
--- a/_conferences/2025/01_index.html
+++ b/_conferences/2025/01_index.html
@@ -15,6 +15,8 @@ id: about
 ---
 <div class="mec2025-page">
 
+    <p><em>Update (2024-12-02):</em> The deadline for submissions is extended to <strong>20 December 2024</strong>. Please see our <a href="/conference/2025/call">Call for Proposals</a> for further details.</p>
+    
     <p><em>Update (2024-10-28):</em> Submission phase has opened. Please see our <a href="/conference/2025/call">Call for Proposals</a> for further details.</p>
       
     <p>The Music Encoding Conference is the annual meeting of the Music Encoding Initiative (MEI) community and all who are interested in the digital representation of music.</p>

--- a/_conferences/2025/02_call.html
+++ b/_conferences/2025/02_call.html
@@ -20,7 +20,7 @@ id: call
   <p><strong>Conference date</strong>: 4–6 June (with pre-conference workshops on the 3rd and un-conference and business meetings day on the 6th)</p>
   <p>Location: City University of London, UK</p>
 
-  <p><strong>Deadline for proposals: 13 December 2024</strong></p>
+  <p><strong>Deadline for proposals: <s>13</s> 20 December 2024</strong></p>
   <p>Notification of acceptance: 13 February 2025</p>
   <p>Registration deadline for authors: 13 April 2025</p>
   <p>Final revision of abstracts: 29 April 2025</p> 
@@ -79,7 +79,7 @@ id: call
 
   <p>Authors are invited to upload their anonymized submission for review to our Conftool website: <a href="https://www.conftool.net/mec2025/">https://www.conftool.net/mec2025/</a></p>
 
-  <p>The deadline for all submissions is <strong>13 December 2024</strong> (see <a href="#dates">IMPORTANT DATES</a> above). All submissions should include a title, author information (only in ConfTool!), a short abstract, up to five keywords and a PDF file of your proposal. Conftool accepts PDF files only. Since review will be anonymous, please ensure that all identifying information is removed from your PDF before submission.</p>
+  <p>The deadline for all submissions is <strong><s>13</s> 20 December 2024</strong> (see <a href="#dates">IMPORTANT DATES</a> above). All submissions should include a title, author information (only in ConfTool!), a short abstract, up to five keywords and a PDF file of your proposal. Conftool accepts PDF files only. Since review will be anonymous, please ensure that all identifying information is removed from your PDF before submission.</p>
 
   <p>
     Please follow <a href="https://docs.google.com/document/d/1pgmwJTRJnBA91sHmJQWV9YBCs1Nz-pFAjIHxioUe9xw/edit?usp=sharing">this GoogleDoc template</a> for your PDF proposals (contact PC if not available). Word counts apply to the text of the proposal, excluding titles, keywords and references.


### PR DESCRIPTION
New and final deadline extension to 20 December 2024