### PR TITLE
board: add public meeting notes for January 7, 2025

### DIFF
--- a/_posts/2025-01-16-mei-board-meetings
+++ b/_posts/2025-01-16-mei-board-meetings
@@ -1,0 +1,15 @@
+---
+layout: post
+title:  "MEI Board Meeting Minutes & Dates"
+date:   2025-01-16
+categories: update
+---
+
+Public agendas and meeting minutes from the MEI Board meetings are posted on the [MEI Board webpage](https://music-encoding.org/community/mei-board.html) under "Protocols of Board Meetings."
+
+The MEI Board will meet on these dates in 2025:
+* January 7, 2025
+* February 3, 2025
+* March 3, 2025
+* April 7, 2025
+* Additional dates may be added

--- a/community/mei-board/protocols/2025-01-07_Virtual-Board-Meeting.md
+++ b/community/mei-board/protocols/2025-01-07_Virtual-Board-Meeting.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: "2025-01-07 Virtual MEI Board Meeting"
+---
+
+# 2025 January 7 Virtual MEI Board Meeting
+
+Present: Anna Kijas, Martha Thomae Elias, Maristella Feustle, Stefan, Münnich, Benjamin Bohl, David Weigl, Anna Plaksin, Laurent Pugin
+
+Regards: Johannes Kepper
+
+Minutes: Anna Kijas
+
+## Agenda
+
+Welcome to newly elected MEI Board members for the 2025-2027 term
+
+- Martha Thomae Elias
+- Benjamin W. Bohl
+- Anna Kijas
+
+Assigning Board Roles
+
+- Anna K. will continue as Administrative Chair
+- Benni and Stefan will remain as Technical Co-Chairs, and Martha will assist as future co-chair
+- Johannes will continue as Financial Officer
+- Additional responsibilities (unofficial roles) assigned:
+  - Social Media & Outreach: Maristella
+  - Liaison to conference and dev workshop: Anna P. (current PC), Johannes
+  - Mailing List & Elections Administrators: Laurent and Martha
+
+Changes to Social Media Presence
+
+- Leaving X for Bluesky and Mastodon
+- Next steps will be shared at February Board meeting
+
+Documentation clean-up
+
+- Documenting and reviewing details for various accounts and log-ins
+
+Calendaring
+
+- ODD meeting dates to be set
+- MEI Board meeting dates
+  - February 3, 2025 (11 AM EST / 5 PM CET)
+  - March 3, 2025 (10 AM EST / 4 PM CET)
+  - April 7, 2025 (10 AM EDT / 4 PM CEST)
+
+Music Encoding Conference
+
+- MEC 2025
+  - 49 submissions received and assigned to reviewers ([view timeline](https://music-encoding.org/conference/2025/call/))
+- Future conferences
+  - Host identified for MEC 2026
+  - Call for Hosts for MEC 2027 will go out in 2025
+    - [Proposal form now live](https://forms.gle/oYKoz9TTimo4sXWD7) on [hosting guidelines page](https://music-encoding.org/conference/hosting-guidelines.html)
+
+**MEI Community**: If you have questions or agenda items you would like the MEI Board to consider in a future meeting, please reach out to Anna Kijas (anna.kijas at tufts.edu) with your input.


### PR DESCRIPTION
Public meeting notes to be added to the [MEI Board webpage](https://music-encoding.org/community/mei-board.html)