### PR TITLE
fix: update Gemfile.lock to latest bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     ffi (1.17.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.29.3)
@@ -46,7 +45,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.9.1)
+    json (2.10.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -68,7 +67,7 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.83.4-arm64-darwin)
       google-protobuf (~> 4.29)
-    sass-embedded (1.83.4-x64-mingw32)
+    sass-embedded (1.83.4-x64-mingw-ucrt)
       google-protobuf (~> 4.29)
     sass-embedded (1.83.4-x86_64-darwin)
       google-protobuf (~> 4.29)
@@ -81,7 +80,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
-  x64-mingw32
+  x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-linux
 
@@ -92,4 +91,4 @@ DEPENDENCIES
   webrick (~> 1.9)
 
 BUNDLED WITH
-   2.3.22
+   2.6.3


### PR DESCRIPTION
This PR updates the Gemfile.lock to use the latest bundler and MINGW64 environments for windows.