### PR TITLE
fix(comparison): fix js to display refactored macros

### DIFF
--- a/archive/resources/js/main.js
+++ b/archive/resources/js/main.js
@@ -23,14 +23,14 @@ const svg3 = d3.select("#modelClassesChart")
     .append("g")
         .attr("transform", `translate(${width / 2}, ${height / 2})`);
         
-const svg4 = d3.select("#macroPeChart")
+const svg4 = d3.select("#macroChart")
     .append("svg")
         .attr("width", width)
         .attr("height", height)
     .append("g")
         .attr("transform", `translate(${width / 2}, ${height / 2})`);
         
-const svg5 = d3.select("#macroDtChart")
+const svg5 = d3.select("#dataChart")
     .append("svg")
         .attr("width", width)
         .attr("height", height)
@@ -97,7 +97,7 @@ function getCharts() {
         
         // Join new data
     const path4 = svg4.selectAll("path")
-        .data(pie(macroPe));
+        .data(pie(macro));
     
     // Enter new arcs
     path4.enter().append("path")
@@ -111,7 +111,7 @@ function getCharts() {
         
         // Join new data
     const path5 = svg5.selectAll("path")
-        .data(pie(macroDt));
+        .data(pie(data));
     
     // Enter new arcs
     path5.enter().append("path")


### PR DESCRIPTION
This PR fixes the rendering of the pie charts on the schema comparison page. 

The macro groups and datatypes pie charts did not show up after the updates in music-encoding/music-encoding#1510. This PR transfers the changes to the js file there to the repo here.


Before:
<img width="590" alt="Screenshot 2025-03-17 134211" src="https://github.com/user-attachments/assets/c277fe3f-bdbc-4f3e-9f97-a42076cbee69" />

After:
<img width="614" alt="after" src="https://github.com/user-attachments/assets/fe867c44-ecb9-4c6c-a4af-30254412446b" />
