### PR TITLE
board: fix protocols

### DIFF
--- a/community/mei-board/protocols/2025-03-03_Virtual-Board-Meeting.md
+++ b/community/mei-board/protocols/2025-03-03_Virtual-Board-Meeting.md
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: "2025-03-03 Virtual MEI Board Meeting"

--- a/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
+++ b/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
@@ -20,8 +20,8 @@ Updates: MEC 2025 (Anna P.)
 
 Updates: Social Media Outreach
 - BlueSky and Mastodon accounts are live
-    - [https://bsky.app/profile/music-encoding.bsky.social](https://bsky.app/profile/music-encoding.bsky.social)
-    - [https://mastodon.social/@MusicEncoding](https://mastodon.social/@MusicEncoding)
+    - <https://bsky.app/profile/music-encoding.bsky.social>
+    - <https://mastodon.social/@MusicEncoding>
 - MEI Community can use [content curation form](https://forms.gle/u8fj95149x1SzcDp9) to send announcements and updates relevant to the MEI community.
 - Questions can be directed to Maristella Feustle (maristella.feustle at unt.edu)
 

--- a/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
+++ b/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: "2025-04-07 Virtual MEI Board Meeting"

--- a/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
+++ b/community/mei-board/protocols/2025-04-07_Virtual-Board-Meeting.md
@@ -20,8 +20,8 @@ Updates: MEC 2025 (Anna P.)
 
 Updates: Social Media Outreach
 - BlueSky and Mastodon accounts are live
-    - https://bsky.app/profile/music-encoding.bsky.social
-    - https://mastodon.social/@MusicEncoding
+    - [https://bsky.app/profile/music-encoding.bsky.social](https://bsky.app/profile/music-encoding.bsky.social)
+    - [https://mastodon.social/@MusicEncoding](https://mastodon.social/@MusicEncoding)
 - MEI Community can use [content curation form](https://forms.gle/u8fj95149x1SzcDp9) to send announcements and updates relevant to the MEI community.
 - Questions can be directed to Maristella Feustle (maristella.feustle at unt.edu)
 


### PR DESCRIPTION
This PR fixes some of the protocols not showing up due to an empty line at the beginning of the file.

It also adds markdown syntax for the links to socials.