### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "weekly"
     labels:
       - "gh actions dependencies"
-    reviewers:
-      - "music-encoding/technical-team-co-chairs"
     groups:
       actions:
         patterns:
@@ -21,8 +19,6 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    reviewers:
-      - "music-encoding/technical-team-co-chairs"
     groups:
       bundler-dependencies:
         patterns:


### PR DESCRIPTION
Removes the [deprecated reviewers option](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) from the dependabot configuration.

If we still want to notify the @music-encoding/technical-team-co-chairs we may setup a `CODEOWNERS` file in the .github directory.
