### PR TITLE
conference: fix blank space and update link reference

### DIFF
--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -117,9 +117,9 @@ id: call
             published as part of the conference program and a Book of Abstracts after the
             conference.</p>
     <p>Authors are invited to upload their anonymized submissions for review to our
-        Conftool website:<a 
+        Conftool website: <a 
                 href="https://www.conftool.net/mec2026/">https://www.conftool.net/mec2026/</a></p>
-    <p>The deadline for all submissions is 28 November 2025 (see <a href="dates">IMPORTANT DATES</a> above).
+    <p>The deadline for all submissions is 28 November 2025 (see <a href="#dates">IMPORTANT DATES</a> above).
         When you upload into ConfTool, you will be asked for Title, Author information and the PDF 
         of your submission. In addition, you will need to supply a short summary abstract and up 
         to five keywords &ndash; these will be used for review assignment,


### PR DESCRIPTION
This PR fixes some minor stuff in the HTML formatting of the CfP.