### PR TITLE
Add link to template and ai-statement to MEC26 CfP

### DIFF
--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -125,7 +125,9 @@ id: call
         to five keywords &ndash; these will be used for review assignment,
         but may also appear on the conference programme and website. Since review will be anonymous, please ensure
         that all identifying information is removed from your PDF before submission. </p>
-    <p>Please see our website for templates for your PDF proposals. Word counts apply to the
+    <p>Please use our <a href="https://tinyurl.com/MEC2026-Template">template at 
+        <code>https://tinyurl.com/MEC2026-Template</code></a>
+         for your PDF proposals. Word counts apply to the
         text of the proposal, excluding titles, keywords and references.</p>
     <h3>Long papers: 1000-1500 words</h3>
     <p>Long papers are expected to present overviews or specific aspects of ongoing or completed

--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -112,8 +112,8 @@ id: call
             accepted submissions will have the opportunity to make non-<span
             >substantive&nbsp;revisions&nbsp;before the conference, to
             address minor corrections or clarifications suggested during the review process. </p>
-    <p>Please also refer to the&nbsp;statement on our website on
-            the use of generative AI in submissions. <br>Accepted abstracts&nbsp;will be
+    <p>Please also refer to our <a href="./ai-statement">statement on
+            the use of generative AI in submissions</a>. <br>Accepted abstracts&nbsp;will be
             published as part of the conference program and a Book of Abstracts after the
             conference.</p>
     <p>Authors are invited to upload their anonymized submissions for review to our

--- a/_conferences/2026/07_ai.html
+++ b/_conferences/2026/07_ai.html
@@ -1,0 +1,48 @@
+---
+layout: conference
+title: "Statement on the use of generative AI"
+permalink: "/conference/2026/ai-statement/"
+tag: MEC2026
+id: statement-ai
+---
+<img src="/images/conference/2025/banner.jpg" class="img-responsive" style="margin-bottom: 1em" alt="Music Encoding Conference banner showing scenes from Clerkenwell, London">
+<div class="mec2025-page">
+    
+    <h2>Statement on the use of generative AI in submissions for MEC 2026</h2>
+    <p>
+        We recognize that authors of academic works use a variety of tools in the research on 
+        which they report, and to prepare the report itself, from simple ones to very sophisticated
+        ones. We note that tools may generate useful and helpful results, but also errors or 
+        misleading claims. Knowing which tools were used is relevant to evaluating
+         and interpreting academic works. 
+    </p>
+    <p>
+        In view of this, we
+    </p>
+    <ol>
+        <li>
+            require authors to report in their work any significant use of software tools, such as 
+            instruments and software that go beyond word processors or typesetters; we now include 
+            in particular text-to-text generative AI among those that should be reported.
+        </li>
+        <li>
+            remind all colleagues that by signing their name as an author of a contribution, they 
+            each individually take full responsibility for all its contents, irrespective of how 
+            the contents were generated. If use of generative AI results in inappropriate 
+            language, plagiarized content, errors, mistakes, incorrect references, or misleading content, 
+            and that output is included in academic works, it is the responsibility of the author(s). This
+            may affect acceptance of your submission.
+        </li>
+        <li>
+            do not accept generative AI language tools as an author; instead authors should refer to (1).
+        </li>
+    </ol>
+
+    <p>
+        This statement is an adapted version of the 
+        <a href="https://blog.arxiv.org/2023/01/31/arxiv-announces-new-policy-on-chatgpt-and-similar-tools/">arXiv 
+            policy for authors’ use of generative AI language tools</a>.
+        We reserve the right to amend this statement as discussions continue and evolve.
+    </p>
+    
+</div>


### PR DESCRIPTION
Added a file for the AI statement (based on last year's) and links to that and the template into the CfP