### PR TITLE
conference: update link to AI statement in conference call

### DIFF
--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -112,7 +112,7 @@ id: call
             accepted submissions will have the opportunity to make non-<span
             >substantive&nbsp;revisions&nbsp;before the conference, to
             address minor corrections or clarifications suggested during the review process. </p>
-    <p>Please also refer to our <a href="./ai-statement">statement on
+    <p>Please also refer to our <a href="/conference/2026/ai-statement">statement on
             the use of generative AI in submissions</a>. <br>Accepted abstracts&nbsp;will be
             published as part of the conference program and a Book of Abstracts after the
             conference.</p>


### PR DESCRIPTION
This PR fixes the link from the CfP page to the AI statement page.