### PR TITLE
conference: CfP ToC, formatting tweak, removing Anna P's chair role

### DIFF
--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -34,7 +34,7 @@ id: call
     <p>Registration deadline for authors: 2 April 2026</p>
     <p>Last changes to abstracts for publication: 24 April 2026</p>
     <p>For further questions, please e-mail 
-        <a href="mailto:conference2025@music-encoding.org">conference2026@music-encoding.org</a></p>
+        <a href="mailto:conference2026@music-encoding.org">conference2026@music-encoding.org</a></p>
     <h2 id="background">Background</h2>
     <p>The Music Encoding Conference&nbsp;provides a forum where researchers and 
         practitioners from varied fields can meet and share new research built on digital music editions and,
@@ -62,7 +62,7 @@ id: call
         opportunity to engage with the tools and good practices developed within the community, and this 
         will be further reinforced by a showcase during the conference, where these tools can also be
         demonstrated.</p>
-    <p>Following a formal program, unconference sessions will be held on 29th May 2025, designed to foster
+    <p>Following a formal program, unconference sessions will be held on 29th May 2026, designed to foster
         collaboration in the community through the meeting of Interest Groups, and open participation in 
         discussions on hot topics that emerge during the conference. Spaces for these meetings have been 
         generously provided by the hosting institution. As part of the conference, we would like to extend
@@ -112,7 +112,7 @@ id: call
         <li>machine learning approaches.</li>
     </ul>
     <h2 id="submissions">Submissions</h2>
-    <p>The Program Committee for the Music Encoding Conference 2025 will accept proposals for papers,
+    <p>The Program Committee for the Music Encoding Conference 2026 will accept proposals for papers,
             posters, panels, showcase demonstrations and workshops in the form of extended abstracts. All
             submissions will be double-blind peer-reviewed by multiple members of the
             committee before a decision is made on acceptance. After the review process, authors of

--- a/_conferences/2026/06_call.html
+++ b/_conferences/2026/06_call.html
@@ -9,6 +9,13 @@ id: call
 <div class="mec2026-page">
 
     <h1>Call for proposals</h1>
+    <ul>
+        <li><a href="#dates">Important dates</a></li>
+        <li><a href="#background">Background</a></li>
+        <li><a href="#topics">Topics</a></li>
+        <li><a href="#submissions">Submissions</a></li>
+        <li><a href="#org">Conference organisation</a></li>
+    </ul>
     <p>We are pleased to announce our call for papers, posters, panels, and workshops for
             the Music Encoding Conference 2026.</p>
     <p>The Music Encoding Conference brings together members from music encoding, analysis, 
@@ -22,7 +29,7 @@ id: call
     <h2 id="dates">Important dates and information</h2>
     <p>Conference date: 26–29 May, 2026</p>
     <p>Location: Morito Memorial Hall, Tokyo University of Science, Tokyo, Japan</p>
-    <p>Deadline for proposals: Friday 28 November 2025 (Anywhere on Earth)</p>
+    <p><strong>Deadline for proposals</strong>: Friday 28 November 2025 (Anywhere on Earth)</p>
     <p>Notification of acceptance: Monday 26 January 2026 </p>
     <p>Registration deadline for authors: 2 April 2026</p>
     <p>Last changes to abstracts for publication: 24 April 2026</p>
@@ -192,7 +199,7 @@ id: call
         <li>Salome Obert, Paderborn University</li>
         <li>Kevin Page, University of Oxford</li>
         <li>Frankie Perry, University of Oxford | British Library</li>
-        <li>Anna Plaksin, Paderborn University (chair)</li>
+        <li>Anna Plaksin, Paderborn University</li>
         <li>Nevin &#350;ahin, Hacettepe University Ankara State
                 Conservatory</li>
         <li>Martha E. Thomae, NOVA University Lisbon</li>


### PR DESCRIPTION
- Added a table of contents at the top of the CfP for navigation
- Made the deadline bold
- Anna Plaksin was listed as chair (and in the e-mail – sorry, Anna)
- Update a few 2025s still in the updated call (thanks to Ich for pointing these out)