### PR TITLE
fix(proceedings): activate proceedings for MEC 2025

### DIFF
--- a/conference/proceedings.md
+++ b/conference/proceedings.md
@@ -7,7 +7,7 @@ title: "Proceedings"
 
 <div class="columns">
     <div class="column col-12 mec-proceedings">
-        {% assign publicationPeriods = "2024,2021,2020,2015–2017,2013–2014" | split: "," %}
+        {% assign publicationPeriods = "2025,2024,2021,2020,2015–2017,2013–2014" | split: "," %}
         {% for period in publicationPeriods %}
             <div class="mec-proceedings-section">
                 <div class="mec-proceedings-section-divider"><span>{{ period }}</span></div>


### PR DESCRIPTION
This PR activates the MEC 2025 proceedings. This tiny step was forgotten in #800, so the proceedings did not show up on the page.